### PR TITLE
PostgreSQL KB Custom Module (KubeBlocks v0.9.5)

### DIFF
--- a/datastore/postgres/k8s_standard/1.0/README.md
+++ b/datastore/postgres/k8s_standard/1.0/README.md
@@ -1,0 +1,150 @@
+# PostgreSQL Database Cluster - KubeBlocks Module
+
+![Version](https://img.shields.io/badge/version-1.0-blue)
+![Cloud](https://img.shields.io/badge/cloud-kubernetes-326CE5)
+
+## Overview
+
+This module creates and manages production-ready PostgreSQL database clusters on Kubernetes using the KubeBlocks operator (v1.0.1). It provides a developer-friendly interface for deploying PostgreSQL instances with built-in high availability, backup/restore capabilities, and automated lifecycle management.
+
+KubeBlocks handles cluster operations including provisioning, scaling, failover, and backup orchestration while this module abstracts the complexity behind a simple configuration interface.
+
+## Environment as Dimension
+
+This module is **environment-aware** and automatically adapts to different deployment contexts:
+
+- **Namespace**: Uses `var.environment.namespace` by default, with optional override via `namespace_override` for multi-tenant scenarios
+- **Cloud Tags**: Automatically applies `var.environment.cloud_tags` to all created resources for cost tracking and governance
+- **Resource Names**: Generates unique cluster names scoped to the environment using standardized naming conventions
+- **Storage Classes**: Can be customized per environment (e.g., premium SSD for production, standard for dev)
+
+The module respects environment boundaries while allowing configuration overrides where needed, making it suitable for deploying the same PostgreSQL cluster configuration across dev, staging, and production environments.
+
+## Resources Created
+
+This module creates the following Kubernetes resources:
+
+- **Cluster** (KubeBlocks CRD) - Main PostgreSQL cluster definition with componentSpecs for primary/replica configuration
+- **Namespace** - Optional custom namespace for cluster isolation (conditionally created when override specified)
+- **Service (Primary)** - Auto-created by KubeBlocks for write operations targeting primary instance (ports 5432 PostgreSQL, 6432 PgBouncer)
+- **Service (Read)** - Terraform-managed read-only service targeting secondary replicas in replication mode (ports 5432, 6432)
+- **Secret** - Auto-created by KubeBlocks containing connection credentials with format `{cluster-name}-conn-credential`
+- **PersistentVolumeClaims** - Storage volumes for PostgreSQL data (one per replica, expandable via spec updates)
+- **Pods** - PostgreSQL instances managed by KubeBlocks StatefulSet controller with configurable resource limits
+- **BackupPolicy** - Embedded backup configuration when backup scheduling is enabled
+- **Restore Annotations** - Cluster annotations for restore-from-backup functionality
+
+## Deployment Modes
+
+### Standalone Mode
+Single PostgreSQL instance suitable for development or non-critical workloads. Provides basic functionality with minimal resource overhead and simplified configuration.
+
+### Replication Mode (Recommended)
+High-availability setup with one primary and configurable read replicas (1-5 instances). Features:
+- Automatic failover when primary fails using KubeBlocks replication topology
+- Read scaling via dedicated read-only service targeting secondary replicas
+- Pod anti-affinity to distribute replicas across different Kubernetes nodes
+- Volume-snapshot backup support for point-in-time recovery
+
+## High Availability Configuration
+
+In replication mode, the module provides:
+
+- **Pod Anti-Affinity**: Distributes replicas across different Kubernetes nodes to survive node failures
+- **Topology**: Uses KubeBlocks `replication` topology for automatic primary/secondary streaming replication
+- **Read Service**: Dedicated endpoint `{cluster-name}-postgresql-read` for read-only queries that load-balances across secondary replicas
+- **Failure Handling**: KubeBlocks automatically promotes secondary to primary during failover scenarios
+- **Node Tolerance**: Configured to schedule on spot instances and specialty nodes with appropriate tolerations
+- **PgBouncer**: Built-in connection pooling available on port 6432 for all endpoints
+
+## Backup & Restore
+
+### Backup Configuration
+Supports automated volume-snapshot backups integrated with KubeBlocks' native backup system:
+- **Method**: Volume-snapshot using Kubernetes CSI snapshots
+- **Schedule**: Configurable cron expression for automated backups (e.g., `"0 2 * * *"` for daily at 2 AM)
+- **Retention**: Configurable retention period (7d, 30d, 1y) managed by KubeBlocks
+- **Integration**: Embedded in cluster spec using KubeBlocks ClusterBackup API
+
+### Restore from Backup
+Clusters can be restored from existing backups using annotation-based restore:
+- Provide backup name in `restore.backup_name` configuration
+- KubeBlocks orchestrates restore process automatically during cluster creation
+- Extended timeout (60 minutes) during restore operations for large datasets
+- Restore status tracked via cluster phase monitoring
+
+## Storage Management
+
+The module supports dynamic storage expansion through KubeBlocks:
+- Initial size specified in `storage.size` configuration
+- Expansion: Update size value and apply - KubeBlocks handles PVC expansion automatically
+- **Cannot be reduced** once provisioned due to Kubernetes PVC limitations
+- Storage class customization per environment supported
+- Automatic volume claim template management
+
+## Version Support
+
+Supported PostgreSQL versions with KubeBlocks v1.0.1:
+- **16.4.0** (default, latest stable)
+- **15.7.0** (stable LTS)
+- **14.8.0** (older LTS)
+- **12.15.0** (legacy support)
+
+Component definitions automatically map to KubeBlocks releases based on major version (e.g., `postgresql-16-1.0.1`).
+
+## Connection Details
+
+The module exposes two connection interfaces through KubeBlocks auto-generated services:
+
+**Writer Interface** (Primary)
+- Direct connection to primary instance for write operations
+- Hostname: `{cluster-name}-postgresql.{namespace}.svc.cluster.local`
+- PostgreSQL Port: 5432 (direct connection)
+- PgBouncer Port: 6432 (connection pooling)
+- Always available regardless of deployment mode
+
+**Reader Interface** (Read Replicas)
+- Load-balanced connection to secondary replicas (replication mode only)
+- Hostname: `{cluster-name}-postgresql-read.{namespace}.svc.cluster.local`
+- PostgreSQL Port: 5432 (direct connection)
+- PgBouncer Port: 6432 (connection pooling)
+- Falls back to writer endpoint in standalone mode
+
+Connection credentials automatically generated by KubeBlocks and stored in Kubernetes secrets.
+
+## PgBouncer Connection Pooling
+
+All PostgreSQL instances include PgBouncer connection pooler:
+- Available on port 6432 for both writer and reader endpoints
+- Reduces connection overhead and improves performance under high load
+- Transparent to applications - use same credentials as direct PostgreSQL connection
+- Recommended for web applications and services with frequent short-lived connections
+
+## Security Considerations
+
+- **Credentials**: Auto-generated by KubeBlocks, stored in Kubernetes Secrets, marked sensitive in outputs
+- **Network**: Services use ClusterIP by default (internal cluster access only)
+- **Secrets Management**: All passwords and connection strings marked as sensitive
+- **RBAC**: Requires permissions for CRD management, namespace creation, and service operations
+- **Pod Security**: Tolerations configured for spot nodes and specialty workloads
+- **Cluster Policies**: Configurable termination policies (DoNotTerminate, Delete, WipeOut)
+
+## Resource Requirements
+
+Default resource allocations per PostgreSQL instance:
+- CPU Request: 500m (minimum guaranteed)
+- CPU Limit: 1000m (maximum allowed)
+- Memory Request: 512Mi (minimum guaranteed)
+- Memory Limit: 1Gi (maximum allowed)
+- Storage: 20Gi (initial allocation, expandable)
+
+These are fully configurable through the module spec and scale with replica count.
+
+## Dependencies
+
+This module requires two critical inputs:
+
+1. **KubeBlocks Operator** - Must be deployed with CRDs ready and release tracking
+2. **Kubernetes Cluster** - Target cluster with sufficient resources and storage classes
+
+The operator dependency uses release_id tracking to ensure proper lifecycle sequencing and prevent race conditions during cluster provisioning.

--- a/datastore/postgres/k8s_standard/1.0/facets.yaml
+++ b/datastore/postgres/k8s_standard/1.0/facets.yaml
@@ -1,10 +1,10 @@
-intent: postgresql
+intent: postgres
 flavor: k8s_standard
 version: '1.0'
 clouds:
 - kubernetes
 description: Creates and manages PostgreSQL database clusters using KubeBlocks operator
-  v0.9.5
+  v1.0.1
 inputs:
   kubeblocks_operator:
     type: '@outputs/kubeblocks-operator'
@@ -12,7 +12,7 @@ inputs:
     displayName: KubeBlocks Operator
     description: KubeBlocks operator installation (CRDs must be ready)
   kubernetes_cluster:
-    type: '@outputs/kubernetes'
+    type: '@facets/kubernetes-details'
     optional: false
     displayName: Kubernetes Cluster
     description: Target Kubernetes cluster
@@ -27,22 +27,21 @@ spec:
     namespace_override:
       type: string
       title: Namespace Override
-      description: (Optional) Specify a custom namespace for the cluster. If not set, the namespace from the environment will be used.
+      description: (Optional) Specify a custom namespace for the cluster. If not set,
+        the namespace from the environment will be used.
       default: ''
     termination_policy:
       type: string
       title: Termination Policy
       description: Controls cluster deletion behavior
       enum:
-      - Delete
       - DoNotTerminate
-      - Halt
+      - Delete
       - WipeOut
       default: Delete
       x-enum-descriptions:
         Delete: Delete pods and PVCs
         DoNotTerminate: Block cluster deletion
-        Halt: Delete pods but keep PVCs
         WipeOut: Delete everything including backups
     postgres_version:
       type: string
@@ -131,12 +130,6 @@ spec:
           title: Enable Pod Anti-Affinity
           description: Distribute replicas across different nodes for better availability
           default: true
-        anti_affinity_type:
-          type: string
-          title: Anti-Affinity Type
-          description: Preferred allows same-node scheduling if needed, Required enforces
-            strict separation
-          default: Preferred
     backup:
       type: object
       title: Backup Configuration
@@ -147,15 +140,6 @@ spec:
           title: Enable Backup
           description: Enable backup configuration for this cluster
           default: false
-        backup_method:
-          type: string
-          title: Backup Method
-          description: Method to use for backups
-          default: volume-snapshot
-          x-ui-visible-if:
-            field: spec.backup.enabled
-            values:
-            - true
         enable_schedule:
           type: boolean
           title: Enable Backup Schedule
@@ -187,7 +171,8 @@ spec:
     restore:
       type: object
       title: Restore Configuration
-      description: Restore cluster from existing backup instead of creating fresh cluster
+      description: Restore cluster from existing backup instead of creating fresh
+        cluster
       properties:
         enabled:
           type: boolean
@@ -207,7 +192,6 @@ spec:
             values:
             - true
   required:
-  - cluster_name
   - postgres_version
   - mode
 outputs:
@@ -219,8 +203,9 @@ iac:
   - main.tf
   - variables.tf
   - outputs.tf
+  - locals.tf
 sample:
-  kind: postgresql
+  kind: postgres
   flavor: k8s_standard
   version: '1.0'
   disabled: true
@@ -240,10 +225,8 @@ sample:
       storage_class: ''
     high_availability:
       enable_pod_anti_affinity: true
-      anti_affinity_type: Preferred
     backup:
       enabled: false
-      backup_method: volume-snapshot
       enable_schedule: false
       schedule_cron: 0 2 * * *
       retention_period: 7d

--- a/datastore/postgres/k8s_standard/1.0/locals.tf
+++ b/datastore/postgres/k8s_standard/1.0/locals.tf
@@ -1,0 +1,83 @@
+# PostgreSQL Cluster Module - Local Variables
+# KubeBlocks v1.0.1
+
+locals {
+  # Cluster configuration
+  cluster_name = "myapp-postgres" # Default cluster name
+  namespace    = try(var.instance.spec.namespace_override, "") != "" ? var.instance.spec.namespace_override : var.environment.namespace
+  replicas     = var.instance.spec.mode == "standalone" ? 1 : lookup(var.instance.spec, "replicas", 2)
+
+  # HA settings
+  ha_enabled               = var.instance.spec.mode == "replication"
+  enable_pod_anti_affinity = local.ha_enabled && lookup(lookup(var.instance.spec, "high_availability", {}), "enable_pod_anti_affinity", true)
+  create_read_service      = true # Always create read service for replication mode
+
+  topology = local.ha_enabled ? "replication" : "standalone"
+
+  # Backup settings - mapped to ClusterBackup API
+  backup_config = lookup(var.instance.spec, "backup", {})
+
+  # Ensure boolean types
+  backup_enabled = try(lookup(local.backup_config, "enabled", false), false) == true
+
+  # Backup schedule settings (for Cluster.spec.backup)
+  backup_schedule_enabled = local.backup_enabled && try(lookup(local.backup_config, "enable_schedule", false), false) == true
+  backup_cron_expression  = try(lookup(local.backup_config, "schedule_cron", "0 2 * * *"), "0 2 * * *")
+  backup_retention_period = try(lookup(local.backup_config, "retention_period", "7d"), "7d")
+
+  # Backup method - (For volume-snapshot, no repo needed)
+  backup_method = "volume-snapshot"
+
+  # Restore configuration - annotation-based restore from backup
+  restore_config  = lookup(var.instance.spec, "restore", {})
+  restore_enabled = lookup(local.restore_config, "enabled", false) == true
+
+  # Restore source details
+  # Backup naming pattern from KubeBlocks:
+  # - Volume-snapshot backups: {cluster-name}-backup-{timestamp}
+  restore_backup_name = lookup(local.restore_config, "backup_name", "")
+
+  # Component definition
+  postgres_version = var.instance.spec.postgres_version
+
+  # Extract major version only (first segment)
+  # For PostgreSQL: 12.15.0 -> 12, 14.8.0 -> 14, 16.4.0 -> 16
+  postgres_major = split(".", local.postgres_version)[0]
+
+  # Build the componentDef such as postgresql-12-1.0.1, postgresql-14-1.0.1, postgresql-16-1.0.1
+  # The release version is fixed at 1.0.1 for the current KubeBlocks addon
+  release_version = "1.0.1"
+
+  component_def = "postgresql-${local.postgres_major}-${local.release_version}"
+
+  # Credentials from data field
+  postgres_username = try(data.kubernetes_secret.postgres_credentials.data["username"], "postgres")
+  postgres_password = try(data.kubernetes_secret.postgres_credentials.data["password"], "")
+
+  # Validate password exists and is not empty
+  password_is_valid = local.postgres_password != "" && length(local.postgres_password) > 0
+
+  postgres_database = "postgres"
+
+  # Writer/Primary endpoint (always exists)
+  writer_host = "${local.cluster_name}-postgresql.${local.namespace}.svc.cluster.local"
+  writer_port = 5432
+
+  # PgBouncer connection pool endpoints
+  pgbouncer_host = local.writer_host
+  pgbouncer_port = 6432
+
+  # Reader endpoint (only for replication mode with read service)
+  reader_host = local.create_read_service ? "${local.cluster_name}-postgresql-read.${local.namespace}.svc.cluster.local" : null
+  reader_port = local.create_read_service ? 5432 : null
+
+  # Writer connection string
+  writer_connection_string = local.password_is_valid ? (
+    "postgresql://${local.postgres_username}:${local.postgres_password}@${local.writer_host}:${local.writer_port}/${local.postgres_database}"
+  ) : null
+
+  # Reader connection string
+  reader_connection_string = (local.reader_host != null && local.password_is_valid) ? (
+    "postgresql://${local.postgres_username}:${local.postgres_password}@${local.reader_host}:${local.reader_port}/${local.postgres_database}"
+  ) : null
+}

--- a/datastore/postgres/k8s_standard/1.0/outputs.tf
+++ b/datastore/postgres/k8s_standard/1.0/outputs.tf
@@ -1,37 +1,4 @@
 locals {
-  # Credentials from data field
-  postgres_username = try(data.kubernetes_secret.postgres_credentials.data["username"], "postgres")
-
-  postgres_password = try(data.kubernetes_secret.postgres_credentials.data["password"], "")
-
-  # Validate password exists and is not empty
-  password_is_valid = local.postgres_password != "" && length(local.postgres_password) > 0
-
-  postgres_database = "postgres"
-
-  # Writer/Primary endpoint (always exists)
-  writer_host = "${local.cluster_name}-postgresql.${local.namespace}.svc.cluster.local"
-  writer_port = 5432
-
-  # PgBouncer connection pool endpoints
-  pgbouncer_host = local.writer_host
-  pgbouncer_port = 6432
-
-  # Reader endpoint (only for replication mode with read service)
-  reader_host = local.create_read_service ? "${local.cluster_name}-postgresql-read.${local.namespace}.svc.cluster.local" : null
-  reader_port = local.create_read_service ? 5432 : null
-
-  # Writer connection string
-  writer_connection_string = local.password_is_valid ? (
-    "postgresql://${local.postgres_username}:${local.postgres_password}@${local.writer_host}:${local.writer_port}/${local.postgres_database}"
-  ) : null
-
-  # Reader connection string
-  reader_connection_string = (local.reader_host != null && local.password_is_valid) ? (
-    "postgresql://${local.postgres_username}:${local.postgres_password}@${local.reader_host}:${local.reader_port}/${local.postgres_database}"
-  ) : null
-
-  # Output attributes
   output_attributes = {
     cluster_name      = local.cluster_name
     namespace         = local.namespace
@@ -48,7 +15,7 @@ locals {
       reader = local.create_read_service ? "${local.cluster_name}-postgresql-read" : null
     }
     selectors = {
-      postgres = {
+      postgresql = {
         "app.kubernetes.io/instance"   = local.cluster_name
         "app.kubernetes.io/managed-by" = "kubeblocks"
         "app.kubernetes.io/name"       = "postgresql"
@@ -56,39 +23,33 @@ locals {
     }
     defaultDatabase = local.postgres_database
   }
-
-  # Output interfaces (credentials and connection details)
   output_interfaces = {
-    # Writer interface (primary/master)
     writer = {
       host              = local.writer_host
       port              = local.writer_port
       username          = local.postgres_username
-      password          = sensitive(local.postgres_password)
+      password          = local.postgres_password
       database          = local.postgres_database
-      connection_string = local.writer_connection_string != null ? sensitive(local.writer_connection_string) : null
+      connection_string = local.writer_connection_string
       pgbouncer_host    = local.pgbouncer_host
       pgbouncer_port    = local.pgbouncer_port
       secrets           = ["password", "connection_string"]
     }
-    # Reader interface (read replicas)
-    # If no read service exists, point to writer
     reader = local.create_read_service ? {
       host              = local.reader_host
       port              = local.reader_port
       username          = local.postgres_username
-      password          = sensitive(local.postgres_password)
+      password          = local.postgres_password
       database          = local.postgres_database
-      connection_string = local.reader_connection_string != null ? sensitive(local.reader_connection_string) : null
+      connection_string = local.reader_connection_string
       secrets           = ["password", "connection_string"]
       } : {
-      # Fallback to writer if no read replicas
       host              = local.writer_host
       port              = local.writer_port
       username          = local.postgres_username
-      password          = sensitive(local.postgres_password)
+      password          = local.postgres_password
       database          = local.postgres_database
-      connection_string = local.writer_connection_string != null ? sensitive(local.writer_connection_string) : null
+      connection_string = local.writer_connection_string
       secrets           = ["password", "connection_string"]
     }
   }

--- a/datastore/postgres/k8s_standard/1.0/variables.tf
+++ b/datastore/postgres/k8s_standard/1.0/variables.tf
@@ -1,15 +1,11 @@
 # PostgreSQL Cluster Module Variables
-# KubeBlocks v0.9.5 - API v1alpha1
+# KubeBlocks v1.0.1 - API v1
 
 variable "instance_name" {
   description = "Instance name from Facets"
   type        = string
 }
-variable "namespace_override" {
-  description = "Optional: Specify a custom namespace for the cluster. If not set, uses environment.namespace."
-  type        = string
-  default     = ""
-}
+
 variable "environment" {
   description = "Environment context from Facets"
   type = object({
@@ -22,7 +18,7 @@ variable "instance" {
   description = "PostgreSQL cluster instance configuration"
   type = object({
     spec = object({
-      cluster_name       = string
+      namespace_override = optional(string)
       termination_policy = string
       postgres_version   = string
       mode               = string
@@ -42,19 +38,18 @@ variable "instance" {
 
       high_availability = optional(object({
         enable_pod_anti_affinity = optional(bool)
-        anti_affinity_type       = optional(string)
       }))
 
       backup = optional(object({
-        enabled                   = optional(bool)
-        enable_schedule           = optional(bool)
-        schedule_cron             = optional(string)
-        retention_period          = optional(string)
-        backup_method             = optional(string)
+        enabled          = optional(bool)
+        enable_schedule  = optional(bool)
+        schedule_cron    = optional(string)
+        retention_period = optional(string)
+        backup_method    = optional(string)
       }))
       restore = optional(object({
-        enabled          = optional(bool)
-        backup_name      = optional(string)
+        enabled     = optional(bool)
+        backup_name = optional(string)
       }))
     })
   })


### PR DESCRIPTION
## Overview
This PR introduces Terraform module for managing PostgreSQL clusters on Kubernetes using the KubeBlocks operator (v0.9.5). The module supports high availability, scheduled and on-demand backups, restore from volume snapshots, and automatic volume expansion. It is designed for production-grade deployments with flexible configuration and seamless integration with KubeBlocks CRDs.

## Key Features

- Cluster Creation:

Deploys a PostgreSQL cluster with configurable topology (standalone or replication), resource limits, storage, and termination policy.

- Namespace Management:

Optionally creates a dedicated namespace for the cluster, with support for importing existing namespaces.

- Backup Management:

Supports both basebackup (requires BackupRepo) and volume-snapshot (uses AWS EBS snapshots directly).
Configurable backup schedule, retention period, and backup method.
Automatic creation of PVC-based BackupRepo when required.

- Restore Workflow:

Annotation-based restore from backup, supporting both manual and scheduled backups.
PITR (Point-in-Time Recovery) support via WAL archiving and timestamp targeting.
Restore logic ensures correct resource dependencies and waits for restore completion.

- Read-Only Service:

Creates a read-only service for replica pods in HA mode, enabling load-balanced read queries.
Volume Expansion:

Automatic detection and graceful expansion of PVCs when storage size is increased in the spec.
No manual OpsRequest needed; KubeBlocks handles expansion internally.

- Connection & Service Discovery:

Exposes connection credentials and primary service endpoints via Terraform data sources for downstream modules and automation.

## Implementation Details

- Terraform Locals:

Encapsulate cluster name, namespace logic, HA settings, backup/restore configuration, and resource references for clean and maintainable code.

- Resource Dependencies:

Explicit depends_on ensures correct ordering for namespace, backup repo, cluster creation, and restore operations.

- Annotations & Labels:

All resources are annotated and labeled for traceability, operator integration, and cloud tagging.

- Advanced Config:

Helm release names are dynamically generated for uniqueness, and advanced config options (timeouts, cleanup, history) are set for reliability.

## Usage

- Cluster Creation:

Configure var.instance.spec with desired topology, resources, storage, backup, and restore options.

- Backup:

Enable backup and choose method (basebackup or volume-snapshot). Schedule and retention can be set.

- Restore:

Set restore.enabled and provide backup_name (and optionally PITR timestamp) to trigger restore from backup.

- Volume Expansion:

Update var.instance.spec.storage.size and apply; PVCs will be expanded automatically.

## Validation & Testing

### Primary Cluster Config

- JSON

```
{
  "flavor": "standard",
  "kind": "postgresql-cluster",
  "inputs": {
    "kubernetes_cluster": {
      "resource_name": "default",
      "resource_type": "kubernetes_cluster"
    },
    "kubeblocks_operator": {
      "resource_name": "test-kubeblocks-op",
      "resource_type": "kubeblocks-operator"
    }
  },
  "disabled": false,
  "version": "1.0",
  "spec": {
    "cluster_name": "myapp-postgres",
    "termination_policy": "WipeOut",
    "postgres_version": "14.8.0",
    "mode": "replication",
    "replicas": 2,
    "resources": {
      "cpu_request": "500m",
      "cpu_limit": "1000m",
      "memory_request": "512Mi",
      "memory_limit": "1Gi"
    },
    "storage": {
      "size": "10Gi",
      "storage_class": ""
    },
    "high_availability": {
      "enable_pod_anti_affinity": true,
      "anti_affinity_type": "Preferred",
      "create_read_service": true
    },
    "backup": {
      "enabled": true,
      "create_backup_repo": true,
      "backup_repo_storage_size": "20Gi",
      "backup_repo_storage_class": "",
      "enable_schedule": true,
      "schedule_cron": "0 2 * * *",
      "retention_period": "7d",
      "backup_method": "volume-snapshot"
    },
    "restore": {
      "enabled": false
    }
  }
}
```

### Screenshots

<img width="896" height="98" alt="image" src="https://github.com/user-attachments/assets/698564fe-cbcb-4b8f-aa6e-6012899818d2" />
---
<img width="854" height="98" alt="image" src="https://github.com/user-attachments/assets/7cef6519-a690-40d1-a3a2-25806a2becb1" />
---
<img width="1111" height="425" alt="image" src="https://github.com/user-attachments/assets/756566c7-a852-456d-9127-e46fcc50af8e" />
---
<img width="1412" height="145" alt="image" src="https://github.com/user-attachments/assets/f68c9413-743e-4303-a9de-18d28e9c581e" />
---
<img width="1419" height="149" alt="image" src="https://github.com/user-attachments/assets/2dc78792-79a3-47a2-9d4c-4a4d958b5db1" />

```
kubectl exec -it myapp-postgres-postgresql-0 -n default -- bash

postgres=# \l
                                  List of databases
   Name    |  Owner   | Encoding |   Collate   |    Ctype    |   Access privileges   
-----------+----------+----------+-------------+-------------+-----------------------
 postgres  | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | 
 template0 | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | =c/postgres          +
           |          |          |             |             | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | =c/postgres          +
           |          |          |             |             | postgres=CTc/postgres
 testdb    | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | 
(4 rows)

postgres=# \c testdb
SELECT * FROM users;
invalid integer value "FROM" for connection option "port"
Previous connection kept
postgres=# \c testdb
You are now connected to database "testdb" as user "postgres".
testdb=# select * from users;
 id |  name   |        email        
----+---------+---------------------
  1 | Alice   | alice@example.com
  2 | Bob     | bob@example.com
  3 | Charlie | charlie@example.com
(3 rows)

testdb=# exit;
root@myapp-postgres-postgresql-0:/home/postgres# exit;
exit
```


```
BACKUP_NAME=$(kubectl get backup -n default -l app.kubernetes.io/instance=myapp-postgres --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[].metadata.name}')
echo "Backup Name: $BACKUP_NAME"
Backup Name: myapp-postgres-volume-snapshot-20251028065000
```

### Restored Cluster Config

- JSON

```
{
  "flavor": "standard",
  "kind": "postgresql-cluster",
  "inputs": {
    "kubernetes_cluster": {
      "resource_name": "default",
      "resource_type": "kubernetes_cluster"
    },
    "kubeblocks_operator": {
      "resource_name": "test-kubeblocks-op",
      "resource_type": "kubeblocks-operator"
    }
  },
  "disabled": false,
  "version": "1.0",
  "spec": {
    "cluster_name": "myapp-postgres-restored",
    "namespace_override": "",
    "termination_policy": "Delete",
    "postgres_version": "14.8.0",
    "mode": "replication",
    "replicas": 1,
    "resources": {
      "cpu_request": "500m",
      "cpu_limit": "1000m",
      "memory_request": "512Mi",
      "memory_limit": "1Gi"
    },
    "storage": {
      "size": "10Gi",
      "storage_class": ""
    },
    "high_availability": {
      "enable_pod_anti_affinity": true,
      "anti_affinity_type": "Preferred",
      "create_read_service": true
    },
    "backup": {
      "enabled": false,
      "backup_method": "volume-snapshot",
      "create_backup_repo": false,
      "backup_repo_storage_size": "20Gi",
      "backup_repo_storage_class": "",
      "enable_schedule": false,
      "schedule_cron": "0 2 * * *",
      "retention_period": "7d",
      "pitr_enabled": false
    },
    "restore": {
      "enabled": true,
      "backup_name": "myapp-postgres-volume-snapshot-20251028065000",
      "pitr_enabled": false,
      "pitr_timestamp": ""
    }
  }
}
```
### Screenshots

<img width="963" height="102" alt="image" src="https://github.com/user-attachments/assets/87270229-635e-4d12-afb0-ca4c600e8a41" />

```
kubectl exec -it myapp-postgres-restored-postgresql-0 -n default -- psql -U postgres
Defaulted container "postgresql" out of: postgresql, pgbouncer, exporter, lorry, config-manager, pg-init-container (init)
psql (14.11 (Ubuntu 14.11-1.pgdg22.04+1))
Type "help" for help.

postgres=# \l
                                  List of databases
   Name    |  Owner   | Encoding |   Collate   |    Ctype    |   Access privileges   
-----------+----------+----------+-------------+-------------+-----------------------
 postgres  | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | 
 template0 | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | =c/postgres          +
           |          |          |             |             | postgres=CTc/postgres
 template1 | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | =c/postgres          +
           |          |          |             |             | postgres=CTc/postgres
 testdb    | postgres | UTF8     | en_US.utf-8 | en_US.utf-8 | 
(4 rows)

postgres=# \c testdb;
You are now connected to database "testdb" as user "postgres".
testdb=# select * from users;
 id |  name   |        email        
----+---------+---------------------
  1 | Alice   | alice@example.com
  2 | Bob     | bob@example.com
  3 | Charlie | charlie@example.com
(3 rows)

testdb=# exit;
```
---
- Cluster creation, backup, and restore flows have been tested and verified.
- PVC and pod events confirm successful volume provisioning and restore completion.
- Database connectivity and data integrity validated post-restore.
- Volume expansion tested via spec update and confirmed via PVC status.

## Notes
Requires KubeBlocks operator `v0.9.5+` and CRDs installed.
AWS EBS CSI driver IAM policy must allow `ec2:CreateVolume` on snapshots for restore to work. (_Added required condition on openid-connect.tf_)
For PITR, ensure WAL archiving(`pg-basebackup`)is enabled in the source cluster.
