### PR TITLE
Fix AWS service module configuration issues

### DIFF
--- a/modules/service/aws/1.0/main.tf
+++ b/modules/service/aws/1.0/main.tf
@@ -24,7 +24,7 @@ locals {
   # Transform taints from object format to string format for utility module compatibility
   kubernetes_node_pool_details = lookup(var.inputs, "kubernetes_node_pool_details", {})
   node_pool_taints             = lookup(local.kubernetes_node_pool_details, "taints", [])
-  node_pool_labels             = lookup(local.kubernetes_node_pool_details, "node_selector", [])
+  node_pool_labels             = lookup(local.kubernetes_node_pool_details, "node_selector", {})
 
   # Convert taints from {key: "key", value: "value", effect: "effect"} to "key=value:effect" format
   transformed_taints = [
@@ -159,7 +159,7 @@ resource "aws_iam_role" "application-role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${var.inputs.kubernetes_details.node_iam_role_arn}"
+        "AWS": "${var.inputs.kubernetes_details.attributes.node_iam_role_arn}"
       },
       "Action": "sts:AssumeRole"
     }


### PR DESCRIPTION
## Summary
- Fixed `node_selector` default value from `[]` to `{}` to match expected map type
- Fixed `node_iam_role_arn` path to include `attributes` accessor

## Details
These changes address type mismatch issues in the AWS service module:

1. **node_selector default value**: Changed from array (`[]`) to object (`{}`) to properly handle kubernetes node pool label selectors which are key-value pairs.

2. **node_iam_role_arn path**: Added `.attributes` to the path (`var.inputs.kubernetes_details.attributes.node_iam_role_arn`) to correctly access the IAM role ARN from the kubernetes cluster details.

## Test plan
- Verify that services with node pool configurations deploy correctly
- Confirm IAM role assumption works properly for EKS workloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)