### PR TITLE
Kubeblocks database addons flavor fix

### DIFF
--- a/datastore/mongo/k8s_standard/1.0/facets.yaml
+++ b/datastore/mongo/k8s_standard/1.0/facets.yaml
@@ -1,8 +1,11 @@
 intent: mongo
-flavor: k8s_standard
+flavor: kubeblocks
 version: '1.0'
 clouds:
 - kubernetes
+- aws
+- azure
+- gcp
 description: Creates and manages MongoDB database clusters using KubeBlocks operator
   v1.0.1
 inputs:
@@ -209,7 +212,7 @@ iac:
   - locals.tf
 sample:
   kind: mongo
-  flavor: k8s_standard
+  flavor: kubeblocks
   version: '1.0'
   disabled: true
   spec:

--- a/datastore/mysql/k8s_standard/1.0/facets.yaml
+++ b/datastore/mysql/k8s_standard/1.0/facets.yaml
@@ -1,8 +1,11 @@
 intent: mysql
-flavor: k8s_standard
+flavor: kubeblocks
 version: '1.0'
 clouds:
 - kubernetes
+- aws
+- azure
+- gcp
 description: Creates and manages MySQL database clusters using KubeBlocks operator
   v1.0.1
 inputs:
@@ -177,7 +180,7 @@ iac:
   - locals.tf
 sample:
   kind: mysql
-  flavor: k8s_standard
+  flavor: kubeblocks
   version: '1.0'
   disabled: true
   spec:

--- a/datastore/postgres/k8s_standard/1.0/facets.yaml
+++ b/datastore/postgres/k8s_standard/1.0/facets.yaml
@@ -1,8 +1,11 @@
 intent: postgres
-flavor: k8s_standard
+flavor: kubeblocks
 version: '1.0'
 clouds:
 - kubernetes
+- aws
+- azure
+- gcp
 description: Creates and manages PostgreSQL database clusters using KubeBlocks operator
   v1.0.1
 inputs:
@@ -177,7 +180,7 @@ iac:
   - locals.tf
 sample:
   kind: postgres
-  flavor: k8s_standard
+  flavor: kubeblocks
   version: '1.0'
   disabled: true
   spec:

--- a/datastore/redis/k8s_standard/1.0/facets.yaml
+++ b/datastore/redis/k8s_standard/1.0/facets.yaml
@@ -1,8 +1,11 @@
 intent: redis
-flavor: k8s_standard
+flavor: kubeblocks
 version: '1.0'
 clouds:
 - kubernetes
+- aws
+- azure
+- gcp
 description: Creates and manages Redis clusters using KubeBlocks operator v1.0.1
 inputs:
   kubeblocks_operator:
@@ -191,7 +194,7 @@ iac:
   - locals.tf
 sample:
   kind: redis
-  flavor: k8s_standard
+  flavor: kubeblocks
   version: '1.0'
   disabled: true
   spec:


### PR DESCRIPTION
### Summary

- Changed `flavor` field from `k8s_standard` to `kubeblocks` in MongoDB, MySQL, PostgreSQL, and Redis datastore modules.
- Updated supported `clouds` to include `aws`, `azure`, and `gcp` in each corresponding `facets.yaml`.
- Adjusted associated sample manifests to reflect the new flavor.

**Impact:**  
Standardizes flavor naming and expands multi-cloud compatibility for KubeBlocks-managed datastores.