### PR TITLE
helm provider version downgrade

### DIFF
--- a/modules/kubernetes_cluster/aks/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/aks/1.0/facets.yaml
@@ -306,7 +306,7 @@ outputs:
           cluster_ca_certificate: cluster_ca_certificate
       helm:
         source: hashicorp/helm
-        version: 2.8.0
+        version: 2.17.0
         attributes:
           kubernetes:
             host: cluster_endpoint

--- a/modules/kubernetes_cluster/eks/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks/1.0/facets.yaml
@@ -39,7 +39,7 @@ outputs:
             args: attributes.kubernetes_provider_exec.args
       helm:
         source: hashicorp/helm
-        version: 3.0.2
+        version: 2.17.0
         attributes:
           kubernetes:
             host: attributes.cluster_endpoint

--- a/modules/kubernetes_cluster/gke/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/gke/1.0/facets.yaml
@@ -89,7 +89,7 @@ outputs:
             args: attributes.kubernetes_provider_exec.args
       helm:
         source: hashicorp/helm
-        version: 3.0.2
+        version: 2.17.0
         attributes:
           kubernetes:
             host: attributes.cluster_endpoint

--- a/outputs/kubernetes-details/outputs.yaml
+++ b/outputs/kubernetes-details/outputs.yaml
@@ -37,4 +37,4 @@ providers:
     version: 0.6.0
   - name: helm
     source: hashicorp/helm
-    version: 3.0.2
+    version: 2.17.0


### PR DESCRIPTION
### Summary:

Helm provider version downgrade. 

The 3.x.x version's are affected. Check - [github-issue](https://github.com/hashicorp/terraform-provider-helm/issues/1669)

### Expected Behavior
helm_release resources that have not been changed do not get their TF state files changed at all
### Actual Behavior
After several successful Terraform apply runs (no changes to any helm_release resources), the terraform state for several (but not all) helm_release resources was updated and those resources completely removed from the state.
This resulted in Terraform trying to recreate those Helm Releases even though they already existed in the EKS cluster, resulting in an error :
`cannot re-use a name that is still in use`
