### PR TITLE
fix eks addon names

### DIFF
--- a/modules/kubernetes_cluster/eks/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks/1.0/facets.yaml
@@ -148,9 +148,6 @@ spec:
                     - adot
                     - aws-privateca-connector-for-kubernetes
                     - sriov-network-metrics-exporter
-                    - amazon-sagemaker-hyperpod-taskgovernance
-                    - amazon-sagemaker-hyperpod-observability
-                    - amazon-sagemaker-hyperpod-training-operator
                   x-ui-typeable: true
                   x-ui-overrides-only: false
                   x-ui-unique: true


### PR DESCRIPTION
## Summary

- Fixed 3 EKS addon names to match official AWS identifiers for EKS 1.33 compatibility and removed other 3 which were specific to **SageMaker HyperPod** clusters

## Fixed Addons

| Before | After |
|--------|-------|
| `eks-node-agent` | `eks-node-monitoring-agent` |
| `aws-network-flow-monitor-agent` | `aws-network-flow-monitoring-agent` |
| `aws-privateca-connector` | `aws-privateca-connector-for-kubernetes` |
| `sagemaker-hyperpod-task-governance` | **removed** |
| `sagemaker-hyperpod-observability` | **removed** |
| `sagemaker-hyperpod-training-operator` | **removed** |
