### PR TITLE
fix: Remove prohibited platform-injected variables (cc_metadata, cluster, baseinfra)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# Facets Module Repository
+
+## Repository Structure
+
+```
+modules/{intent}/{flavor}/{version}/   - Core infrastructure modules
+datastore/{tech}/{flavor}/{version}/   - Database modules
+outputs/{type-name}/                   - Output type schemas (@facets/*)
+```
+
+## Module Files
+
+| File | Purpose |
+|------|---------|
+| `facets.yaml` | Module definition (spec schema, inputs, outputs, sample) |
+| `variables.tf` | `var.instance` (spec) and `var.inputs` (dependencies) |
+| `main.tf` | Terraform resources |
+| `locals.tf` | `output_attributes` and `output_interfaces` |
+| `outputs.tf` | Terraform outputs |
+
+## Raptor Commands
+
+```bash
+# Validate module (always start with this)
+raptor create iac-module -f <module-path> --dry-run
+
+# If security scan fails, retry with skip (but report findings to user)
+raptor create iac-module -f <module-path> --dry-run --skip-security-scan
+
+# Upload after validation passes
+raptor create iac-module -f <module-path>
+```
+
+## Finding Module Standards
+
+Look for `*_module_standard*.md` in the relevant directory:
+- `modules/service/` → `service_module_standard.md`
+- `modules/network/` → `network_module_standard.md`
+- `modules/cloud_account/` → `cloud_account_module_standard.md`
+- `modules/kubernetes_node_pool/` → `kubernetes_node_pool_module_standard.md`
+- `modules/workload_identity/` → `workload_identity_module_standard.md`
+- `datastore/` → `datastore_module_standards.md`
+
+## Validation Rules
+
+See **rules.md** for complete validation ruleset with good/bad examples.
+
+## Behavior Guidelines
+
+- **NEVER** auto-skip validation - always report issues to user
+- Report security scan results in **table format**
+- Branch naming: `fix/<issue-number>-<short-description>`
+- If provider issues (aws3tooling, facets provider), **report to user**
+- **NEVER** use `--skip-validation` flag

--- a/aws/service/aws/1.0/data.tf
+++ b/aws/service/aws/1.0/data.tf
@@ -1,0 +1,32 @@
+# Read control plane metadata from environment variables
+# This replaces the deprecated var.cc_metadata, var.cluster, var.baseinfra pattern
+data "external" "cc_env" {
+  program = ["sh", "-c", <<-EOT
+    echo "{\"cc_host\":\"$TF_VAR_cc_host\",\"cc_auth_token\":\"$TF_VAR_cc_auth_token\",\"cc_region\":\"$TF_VAR_cc_region\",\"cc_tenant_provider\":\"$TF_VAR_cc_tenant_provider\",\"tenant_base_domain\":\"$TF_VAR_tenant_base_domain\",\"tenant_base_domain_id\":\"$TF_VAR_tenant_base_domain_id\"}"
+  EOT
+  ]
+}
+
+locals {
+  # Control plane metadata constructed from environment variables
+  # This object is passed to utility modules that expect cc_metadata
+  cc_metadata = {
+    cc_host               = data.external.cc_env.result.cc_host
+    cc_auth_token         = data.external.cc_env.result.cc_auth_token
+    cc_region             = data.external.cc_env.result.cc_region
+    cc_tenant_provider    = data.external.cc_env.result.cc_tenant_provider
+    tenant_base_domain    = data.external.cc_env.result.tenant_base_domain
+    tenant_base_domain_id = data.external.cc_env.result.tenant_base_domain_id
+  }
+
+  # Cluster metadata from environment variable
+  cluster = {
+    id                       = var.environment.cluster_id
+    createdBy                = null
+    k8sRequestsToLimitsRatio = 1
+  }
+
+  # Base infrastructure - empty object as placeholder
+  # Utility module may not actually use this
+  baseinfra = {}
+}

--- a/aws/service/aws/1.0/main.tf
+++ b/aws/service/aws/1.0/main.tf
@@ -130,10 +130,10 @@ module "app-helm-chart" {
   values                  = local.instance_with_vpa_config
   annotations             = local.annotations
   registry_secret_objects = length(local.from_artifactories) > 0 ? local.from_artifactories : local.from_kubernetes_cluster
-  cc_metadata             = var.cc_metadata
-  baseinfra               = var.baseinfra
+  cc_metadata             = local.cc_metadata
+  baseinfra               = local.baseinfra
   labels                  = local.labels
-  cluster                 = var.cluster
+  cluster                 = local.cluster
   environment             = var.environment
   inputs                  = local.modified_inputs
   vpa_release_id          = lookup(lookup(lookup(var.inputs, "vpa_details", {}), "attributes", {}), "helm_release_id", "")

--- a/azure/service/azure/1.0/data.tf
+++ b/azure/service/azure/1.0/data.tf
@@ -1,0 +1,32 @@
+# Read control plane metadata from environment variables
+# This replaces the deprecated var.cc_metadata, var.cluster, var.baseinfra pattern
+data "external" "cc_env" {
+  program = ["sh", "-c", <<-EOT
+    echo "{\"cc_host\":\"$TF_VAR_cc_host\",\"cc_auth_token\":\"$TF_VAR_cc_auth_token\",\"cc_region\":\"$TF_VAR_cc_region\",\"cc_tenant_provider\":\"$TF_VAR_cc_tenant_provider\",\"tenant_base_domain\":\"$TF_VAR_tenant_base_domain\",\"tenant_base_domain_id\":\"$TF_VAR_tenant_base_domain_id\"}"
+  EOT
+  ]
+}
+
+locals {
+  # Control plane metadata constructed from environment variables
+  # This object is passed to utility modules that expect cc_metadata
+  cc_metadata = {
+    cc_host               = data.external.cc_env.result.cc_host
+    cc_auth_token         = data.external.cc_env.result.cc_auth_token
+    cc_region             = data.external.cc_env.result.cc_region
+    cc_tenant_provider    = data.external.cc_env.result.cc_tenant_provider
+    tenant_base_domain    = data.external.cc_env.result.tenant_base_domain
+    tenant_base_domain_id = data.external.cc_env.result.tenant_base_domain_id
+  }
+
+  # Cluster metadata from environment variable
+  cluster = {
+    id                       = var.environment.cluster_id
+    createdBy                = null
+    k8sRequestsToLimitsRatio = 1
+  }
+
+  # Base infrastructure - empty object as placeholder
+  # Utility module may not actually use this
+  baseinfra = {}
+}

--- a/azure/service/azure/1.0/main.tf
+++ b/azure/service/azure/1.0/main.tf
@@ -165,9 +165,9 @@ module "app-helm-chart" {
   annotations             = local.annotations
   labels                  = local.labels
   registry_secret_objects = length(local.from_artifactories) > 0 ? local.from_artifactories : local.from_kubernetes_cluster
-  cc_metadata             = var.cc_metadata
-  baseinfra               = var.baseinfra
-  cluster                 = var.cluster
+  cc_metadata             = local.cc_metadata
+  baseinfra               = local.baseinfra
+  cluster                 = local.cluster
   environment             = var.environment
   inputs                  = var.inputs
   vpa_release_id          = lookup(lookup(lookup(var.inputs, "vpa_details", {}), "attributes", {}), "helm_release_id", "")

--- a/common/cert_manager/standard/1.0/README.md
+++ b/common/cert_manager/standard/1.0/README.md
@@ -14,7 +14,7 @@ This module adapts to different cloud environments:
 - **Azure**: Uses existing DNS credentials for certificate validation  
 - **GCP**: Integrates with Google Cloud DNS for certificate validation and supports GTS certificates
 
-The module automatically detects the cloud provider from `var.cc_metadata.cc_tenant_provider` and configures appropriate DNS solvers and authentication mechanisms.
+The module automatically detects the cloud provider from the `TF_VAR_cc_tenant_provider` environment variable and configures appropriate DNS solvers and authentication mechanisms.
 
 ## Nodepool Integration
 

--- a/common/cert_manager/standard/1.0/data.tf
+++ b/common/cert_manager/standard/1.0/data.tf
@@ -1,0 +1,15 @@
+# Read control plane metadata from environment variables
+# This replaces the deprecated var.cc_metadata and var.cluster pattern
+data "external" "cc_env" {
+  program = ["sh", "-c", <<-EOT
+    echo "{\"cc_tenant_provider\":\"$TF_VAR_cc_tenant_provider\",\"cc_region\":\"$TF_VAR_cc_region\",\"tenant_base_domain_id\":\"$TF_VAR_tenant_base_domain_id\"}"
+  EOT
+  ]
+}
+
+locals {
+  # Control plane metadata from environment variables
+  cc_tenant_provider    = data.external.cc_env.result.cc_tenant_provider
+  cc_region             = data.external.cc_env.result.cc_region
+  tenant_base_domain_id = data.external.cc_env.result.tenant_base_domain_id
+}

--- a/common/cert_manager/standard/1.0/locals.tf
+++ b/common/cert_manager/standard/1.0/locals.tf
@@ -1,6 +1,6 @@
 # Define your locals here
 locals {
-  tenant_provider           = lower(try(var.cc_metadata.cc_tenant_provider, "aws"))
+  tenant_provider           = lower(local.cc_tenant_provider != "" ? local.cc_tenant_provider : "aws")
   spec                      = lookup(var.instance, "spec", {})
   user_supplied_helm_values = try(local.spec.cert_manager.values, try(var.instance.advanced.cert_manager.values, {}))
   cert_manager              = lookup(local.spec, "cert_manager", try(var.instance.advanced.cert_manager, {}))
@@ -13,7 +13,7 @@ locals {
   dns_providers = {
     aws = {
       route53 = {
-        region = try(var.cc_metadata.cc_region, null)
+        region = local.cc_region != "" ? local.cc_region : null
         accessKeyIDSecretRef = {
           key  = "access-key-id"
           name = local.disable_dns_validation ? "na" : kubernetes_secret.cert_manager_r53_secret[0].metadata[0].name
@@ -110,7 +110,7 @@ locals {
   # GTS and ACME configuration
   use_gts         = lookup(local.spec, "use_gts", false)
   gts_private_key = lookup(local.spec, "gts_private_key", "")
-  acme_email      = lookup(local.spec, "acme_email", "") != "" ? lookup(local.spec, "acme_email", "") : try(var.cluster.createdBy, null)
+  acme_email      = lookup(local.spec, "acme_email", "") != "" ? lookup(local.spec, "acme_email", "") : null
 }
 
 data "kubernetes_secret_v1" "dns" {

--- a/common/cert_manager/standard/1.0/main.tf
+++ b/common/cert_manager/standard/1.0/main.tf
@@ -48,7 +48,7 @@ resource "aws_iam_user_policy" "cert_manager_r53_policy" {
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets"
       ],
-      "Resource": "arn:aws:route53:::hostedzone/${try(var.cc_metadata.tenant_base_domain_id, "*")}"
+      "Resource": "arn:aws:route53:::hostedzone/${local.tenant_base_domain_id != "" ? local.tenant_base_domain_id : "*"}"
     },
     {
       "Effect": "Allow",

--- a/common/ingress/nginx_k8s/1.0/data.tf
+++ b/common/ingress/nginx_k8s/1.0/data.tf
@@ -1,0 +1,15 @@
+# Read control plane metadata from environment variables
+# This replaces the deprecated var.cc_metadata pattern
+data "external" "cc_env" {
+  program = ["sh", "-c", <<-EOT
+    echo "{\"cc_tenant_provider\":\"$TF_VAR_cc_tenant_provider\",\"tenant_base_domain\":\"$TF_VAR_tenant_base_domain\",\"tenant_base_domain_id\":\"$TF_VAR_tenant_base_domain_id\"}"
+  EOT
+  ]
+}
+
+locals {
+  # Control plane metadata from environment variables
+  cc_tenant_provider    = data.external.cc_env.result.cc_tenant_provider
+  tenant_base_domain    = data.external.cc_env.result.tenant_base_domain
+  tenant_base_domain_id = data.external.cc_env.result.tenant_base_domain_id
+}

--- a/common/k8s_callback/k8s_standard/1.0/main.tf
+++ b/common/k8s_callback/k8s_standard/1.0/main.tf
@@ -61,16 +61,18 @@ resource "null_resource" "add_k8s_creds_backend" {
   triggers = {
     host       = var.inputs.kubernetes_details.attributes.cluster_endpoint
     token      = data.kubernetes_secret.facets_admin_token.data["token"]
-    cluster_id = var.cluster.id
+    cluster_id = var.environment.cluster_id
   }
 
   provisioner "local-exec" {
+    # Use TF_VAR_* environment variables directly in shell command
+    # This replaces the deprecated var.cc_metadata pattern
     command = <<EOF
-curl -X POST "https://${var.cc_metadata.cc_host}/cc/v1/clusters/${var.cluster.id}/credentials" \
+curl -X POST "https://$TF_VAR_cc_host/cc/v1/clusters/${var.environment.cluster_id}/credentials" \
   -H "accept: */*" \
   -H "Content-Type: application/json" \
   -d "{\"kubernetesApiEndpoint\": \"${var.inputs.kubernetes_details.attributes.cluster_endpoint}\", \"kubernetesToken\": \"${data.kubernetes_secret.facets_admin_token.data["token"]}\"}" \
-  -H "X-DEPLOYER-INTERNAL-AUTH-TOKEN: ${var.cc_metadata.cc_auth_token}"
+  -H "X-DEPLOYER-INTERNAL-AUTH-TOKEN: $TF_VAR_cc_auth_token"
 EOF
   }
 

--- a/common/k8s_callback/k8s_standard/1.0/variables.tf
+++ b/common/k8s_callback/k8s_standard/1.0/variables.tf
@@ -20,6 +20,7 @@ variable "environment" {
     unique_name = string
     namespace   = optional(string)
     cloud       = optional(string)
+    cluster_id  = optional(string)
   })
 }
 

--- a/common/prometheus/k8s_standard/1.0/data.tf
+++ b/common/prometheus/k8s_standard/1.0/data.tf
@@ -1,0 +1,14 @@
+# Read control plane metadata from environment variables
+# This replaces the deprecated var.cc_metadata pattern
+data "external" "cc_env" {
+  program = ["sh", "-c", <<-EOT
+    echo "{\"cc_host\":\"$TF_VAR_cc_host\",\"cc_auth_token\":\"$TF_VAR_cc_auth_token\"}"
+  EOT
+  ]
+}
+
+locals {
+  # Control plane metadata from environment variables
+  cc_host       = data.external.cc_env.result.cc_host
+  cc_auth_token = data.external.cc_env.result.cc_auth_token
+}

--- a/common/prometheus/k8s_standard/1.0/locals.tf
+++ b/common/prometheus/k8s_standard/1.0/locals.tf
@@ -241,10 +241,10 @@ locals {
                 send_resolved = true
               },
               {
-                url           = "https://${var.cc_metadata.cc_host}/cc/v1/clusters/${var.environment.cloud_tags.facetsclusterid}/alerts"
+                url           = "https://${local.cc_host}/cc/v1/clusters/${var.environment.cluster_id}/alerts"
                 send_resolved = true
                 http_config = {
-                  bearer_token = var.cc_metadata.cc_auth_token
+                  bearer_token = local.cc_auth_token
                 }
               }
             ]
@@ -284,12 +284,12 @@ locals {
           cookie_samesite = "none"
         }
         server = {
-          domain              = var.cc_metadata.cc_host
-          root_url            = "%(protocol)s://%(domain)s:%(http_port)s/tunnel/${var.environment.cloud_tags.facetsclusterid}/grafana/"
+          domain              = local.cc_host
+          root_url            = "%(protocol)s://%(domain)s:%(http_port)s/tunnel/${var.environment.cluster_id}/grafana/"
           serve_from_sub_path = true
         }
         live = {
-          allowed_origins = "https://${var.cc_metadata.cc_host}"
+          allowed_origins = "https://${local.cc_host}"
         }
         "auth.anonymous" = {
           enabled  = true

--- a/gcp/service/gcp/1.0/application/main.tf
+++ b/gcp/service/gcp/1.0/application/main.tf
@@ -59,17 +59,11 @@ locals {
   memory       = lookup(local.size, "memory", "1000Mi")
   memory_limit = lookup(local.size, "memory_limit", local.memory)
 
-  # We need to split cpu/memory limit as it may contain unit
-  split_cpu_limit          = regex("([0-9.]+)([a-zA-Z]+)?", local.cpu_limit)
-  processed_cpu_request    = "${local.split_cpu_limit[0] * var.cluster.k8sRequestsToLimitsRatio}${local.split_cpu_limit[1] != null ? local.split_cpu_limit[1] : ""}"
-  split_memory_limit       = regex("([0-9.]+)([a-zA-Z]+)?", local.memory_limit)
-  processed_memory_request = "${local.split_memory_limit[0] * var.cluster.k8sRequestsToLimitsRatio}${local.split_memory_limit[1] != null ? local.split_memory_limit[1] : ""}"
-
   processed_size = {
     cpu_limit    = lookup(local.size, "cpu_limit", local.cpu_limit)
-    cpu          = lookup(local.size, "cpu", local.processed_cpu_request)
+    cpu          = lookup(local.size, "cpu", local.cpu)
     memory_limit = lookup(local.size, "memory_limit", local.memory_limit)
-    memory       = lookup(local.size, "memory", local.processed_memory_request)
+    memory       = lookup(local.size, "memory", local.memory)
   }
 
   type           = lookup(var.values.spec, "type", "application")

--- a/gcp/service/gcp/1.0/application/variables.tf
+++ b/gcp/service/gcp/1.0/application/variables.tf
@@ -18,12 +18,8 @@ variable "labels" {
   type = any
 }
 
-variable "cluster" {
-  type = any
-}
-
 variable "environment" {
-  
+
 }
 
 variable "inputs" {

--- a/gcp/service/gcp/1.0/main.tf
+++ b/gcp/service/gcp/1.0/main.tf
@@ -158,7 +158,6 @@ module "app-helm-chart" {
   values         = local.instance
   annotations    = local.annotations
   labels         = local.labels
-  cluster        = var.cluster
   environment    = var.environment
   inputs         = var.inputs
   vpa_release_id = lookup(lookup(lookup(var.inputs, "vpa_details", {}), "attributes", {}), "helm_release_id", "")

--- a/rules.md
+++ b/rules.md
@@ -1,0 +1,528 @@
+# Facets Module Validation Rules
+
+This document contains validation rules for Facets modules. Each rule includes bad and good examples.
+
+---
+
+## Sample.spec Rules
+
+### RULE-001: Required fields must be present
+
+All required fields from spec schema must exist in sample, even with empty values.
+
+**Bad:**
+```yaml
+sample:
+  spec: {}
+```
+
+**Good:**
+```yaml
+sample:
+  spec:
+    cloud_account: ""
+    region: ""
+```
+
+---
+
+### RULE-002: Enum values must match schema
+
+Sample values must be valid enum options defined in the spec schema.
+
+**Bad:**
+```yaml
+sample:
+  spec:
+    cluster_addons:
+      addon1:
+        name: metrics-server  # Not in allowed enum
+```
+
+**Good:**
+```yaml
+sample:
+  spec:
+    cluster_addons:
+      addon1:
+        name: eks-node-agent  # Valid enum value
+```
+
+---
+
+### RULE-003: Use {} for objects, [] for arrays, never null
+
+When schema defines `type: object`, use `{}`. When schema defines `type: array`, use `[]`. Never use `null`.
+
+**Bad:**
+```yaml
+sample:
+  spec:
+    values: null
+    tolerations: []  # Wrong if schema says type: object
+```
+
+**Good:**
+```yaml
+sample:
+  spec:
+    values: {}
+    tolerations: {}  # Correct for type: object with patternProperties
+```
+
+---
+
+## var.inputs Rules
+
+### Finding Input/Output Type Schemas
+
+To build correct `var.inputs` types, you need to know the schema of each input type. Two ways to find it:
+
+1. **From `outputs/` directory:**
+   ```
+   outputs/{type-name}/outputs.yaml
+   ```
+   Example: For `@facets/aws_cloud_account`, check `outputs/aws_cloud_account/outputs.yaml`
+
+2. **Using raptor CLI:**
+   ```bash
+   raptor get output-type @facets/aws_cloud_account
+   ```
+
+---
+
+### RULE-004: Explicit object type required
+
+`var.inputs` must use explicit `object({...})`, NOT `type = any` or `map(any)`.
+
+**Bad:**
+```hcl
+variable "inputs" {
+  type = any
+}
+
+variable "inputs" {
+  type = map(any)
+}
+```
+
+**Good:**
+```hcl
+variable "inputs" {
+  type = object({
+    cloud_account = object({
+      attributes = optional(object({
+        region = optional(string)
+      }), {})
+      interfaces = optional(object({}), {})
+    })
+  })
+}
+```
+
+---
+
+### RULE-005: All facets.yaml inputs must exist in var.inputs
+
+Every input declared in facets.yaml must have a corresponding entry in var.inputs.
+
+**facets.yaml:**
+```yaml
+inputs:
+  cloud_account:
+    type: "@facets/aws_cloud_account"
+  kubernetes_details:
+    type: "@facets/eks"
+```
+
+**Bad (missing kubernetes_details):**
+```hcl
+variable "inputs" {
+  type = object({
+    cloud_account = object({...})
+    # kubernetes_details is missing!
+  })
+}
+```
+
+**Good:**
+```hcl
+variable "inputs" {
+  type = object({
+    cloud_account = object({...})
+    kubernetes_details = object({
+      attributes = optional(object({...}), {})
+      interfaces = optional(object({}), {})
+    })
+  })
+}
+```
+
+---
+
+### RULE-006: Use attributes/interfaces structure
+
+All inputs must follow the standard `attributes`/`interfaces` pattern, not flat structure.
+
+**Bad:**
+```hcl
+variable "inputs" {
+  type = object({
+    aks_cluster = object({
+      oidc_issuer_url = optional(string)  # Flat structure!
+      cluster_id = optional(string)
+    })
+  })
+}
+```
+
+**Good:**
+```hcl
+variable "inputs" {
+  type = object({
+    aks_cluster = object({
+      attributes = optional(object({
+        oidc_issuer_url = optional(string)
+        cluster_id = optional(string)
+      }), {})
+      interfaces = optional(object({}), {})
+    })
+  })
+}
+```
+
+---
+
+## Spec Schema Rules
+
+### RULE-007: No regex lookahead/lookbehind
+
+JSON Schema regex does not support `(?=)`, `(?!)`, `(?<=)`, `(?<!)`.
+
+**Bad:**
+```yaml
+properties:
+  port:
+    type: string
+    pattern: ^(?!0$)([1-9][0-9]{0,3}|[1-5][0-9]{4})$
+```
+
+**Good:**
+```yaml
+properties:
+  port:
+    type: string
+    pattern: ^([1-9][0-9]{0,3}|[1-5][0-9]{4})$
+```
+
+**Bad (domain validation):**
+```yaml
+pattern: ^(?=.{1,253}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\..*)?$
+```
+
+**Good:**
+```yaml
+pattern: ^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$
+```
+
+---
+
+### RULE-008: No duplicate enum values
+
+Enum arrays must not contain duplicate values.
+
+**Bad:**
+```yaml
+properties:
+  header_name:
+    enum:
+      - X-Frame-Options
+      - Cache-Control
+      - Cache-Control  # Duplicate!
+      - Vary
+```
+
+**Good:**
+```yaml
+properties:
+  header_name:
+    enum:
+      - X-Frame-Options
+      - Cache-Control
+      - Vary
+```
+
+---
+
+### RULE-009: required inside patternProperties
+
+Place `required` array inside the pattern definition, not as a sibling of `patternProperties`.
+
+**Bad:**
+```yaml
+rules:
+  type: object
+  patternProperties:
+    ^[a-zA-Z0-9_.-]*$:
+      type: object
+      properties:
+        service_name: {type: string}
+        path: {type: string}
+        port: {type: string}
+  required:  # Wrong! This is sibling of patternProperties
+    - service_name
+    - path
+    - port
+```
+
+**Good:**
+```yaml
+rules:
+  type: object
+  patternProperties:
+    ^[a-zA-Z0-9_.-]*$:
+      type: object
+      properties:
+        service_name: {type: string}
+        path: {type: string}
+        port: {type: string}
+      required:  # Correct! Inside the pattern definition
+        - service_name
+        - path
+        - port
+```
+
+---
+
+## Output Schema Rules
+
+### RULE-010: Explicit type: object for nested objects
+
+Every nested object in output schema must have explicit `type: object` field.
+
+**Bad:**
+```yaml
+# outputs/my-type/outputs.yaml
+attributes:
+  properties:
+    region:
+      type: string
+```
+
+**Good:**
+```yaml
+# outputs/my-type/outputs.yaml
+attributes:
+  type: object
+  properties:
+    region:
+      type: string
+```
+
+---
+
+### RULE-011: No union types
+
+Don't use array syntax for types in output schemas.
+
+**Bad:**
+```yaml
+properties:
+  vpc_endpoint_id:
+    type:
+      - string
+      - "null"
+```
+
+**Good:**
+```yaml
+properties:
+  vpc_endpoint_id:
+    type: string
+```
+
+---
+
+### RULE-012: Field names must match actual outputs
+
+Output schema field names must match what the module actually outputs in `locals.tf`.
+
+**Bad (schema says `project` but module outputs `project_id`):**
+```yaml
+# outputs.yaml
+attributes:
+  type: object
+  properties:
+    project:
+      type: string
+```
+
+```hcl
+# locals.tf
+output_attributes = {
+  project_id = data.google_project.current.project_id
+}
+```
+
+**Good:**
+```yaml
+# outputs.yaml
+attributes:
+  type: object
+  properties:
+    project_id:
+      type: string
+```
+
+```hcl
+# locals.tf
+output_attributes = {
+  project_id = data.google_project.current.project_id
+}
+```
+
+---
+
+## Terraform Rules
+
+### RULE-013: No required_providers in modules
+
+Modules should not define `required_providers` blocks. Providers are injected by the Facets platform.
+
+**Bad:**
+```hcl
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+```
+
+**Good:**
+```hcl
+terraform {
+  required_version = ">= 1.0"
+}
+```
+
+---
+
+### RULE-014: All referenced variables must be declared
+
+Every variable referenced in Terraform code must be declared in `variables.tf`.
+
+**Bad:**
+```hcl
+# main.tf
+resource "kubernetes_namespace" "ns" {
+  metadata {
+    name = var.some_undeclared_var.namespace  # not declared!
+  }
+}
+```
+
+**Good:**
+```hcl
+# variables.tf
+variable "instance" {
+  type = object({
+    spec = object({
+      namespace = optional(string)
+    })
+  })
+}
+
+# main.tf
+resource "kubernetes_namespace" "ns" {
+  metadata {
+    name = var.instance.spec.namespace
+  }
+}
+```
+
+---
+
+### RULE-015: Prohibited platform-injected variables
+
+The following legacy platform-injected variables are **PROHIBITED** and must never be used in modules:
+- `var.cc_metadata`
+- `var.cluster`
+- `var.baseinfra`
+
+Raptor validation will flag and fail modules using these variables.
+
+**Bad:**
+```hcl
+# Using prohibited variables
+resource "null_resource" "callback" {
+  provisioner "local-exec" {
+    command = "curl https://${var.cc_metadata.cc_host}/api"
+  }
+}
+
+locals {
+  cluster_id = var.cluster.id
+}
+```
+
+**Good - For null_resource (use env vars directly):**
+```hcl
+# Access TF_VAR_* environment variables directly in shell commands
+resource "null_resource" "callback" {
+  provisioner "local-exec" {
+    command = "curl https://$TF_VAR_cc_host/api -H \"Authorization: Bearer $TF_VAR_cc_auth_token\""
+  }
+}
+```
+
+**Good - For Terraform resources (use data external):**
+```hcl
+# Use data external to read environment variables
+data "external" "env" {
+  program = ["sh", "-c", "echo '{\"cc_host\":\"'$TF_VAR_cc_host'\",\"cc_auth_token\":\"'$TF_VAR_cc_auth_token'\"}'"]
+}
+
+locals {
+  cc_host       = data.external.env.result.cc_host
+  cc_auth_token = data.external.env.result.cc_auth_token
+}
+```
+
+**Available environment variables:**
+| Env Variable | Description |
+|--------------|-------------|
+| `TF_VAR_cc_host` | Control plane host |
+| `TF_VAR_cc_auth_token` | Control plane auth token |
+| `TF_VAR_cc_region` | Region |
+| `TF_VAR_cc_vpc_id` | VPC ID |
+| `TF_VAR_cc_vpc_cidr` | VPC CIDR |
+| `TF_VAR_cc_tf_state_bucket` | Terraform state bucket |
+| `TF_VAR_cc_tf_state_region` | Terraform state region |
+| `TF_VAR_cc_tf_dynamo_table` | DynamoDB lock table |
+
+---
+
+## Quick Reference
+
+| Rule | Category | Summary |
+|------|----------|---------|
+| RULE-001 | sample.spec | Required fields must be present |
+| RULE-002 | sample.spec | Enum values must match schema |
+| RULE-003 | sample.spec | Use {} for objects, [] for arrays |
+| RULE-004 | var.inputs | Explicit object type required |
+| RULE-005 | var.inputs | All facets.yaml inputs must exist |
+| RULE-006 | var.inputs | Use attributes/interfaces structure |
+| RULE-007 | spec schema | No regex lookahead/lookbehind |
+| RULE-008 | spec schema | No duplicate enum values |
+| RULE-009 | spec schema | required inside patternProperties |
+| RULE-010 | output schema | Explicit type: object for nested |
+| RULE-011 | output schema | No union types |
+| RULE-012 | output schema | Field names match actual outputs |
+| RULE-013 | terraform | No required_providers in modules |
+| RULE-014 | terraform | All variables must be declared |
+| RULE-015 | terraform | No cc_metadata, cluster, baseinfra vars |


### PR DESCRIPTION
## Summary
- Fixes #95
- Removes usage of prohibited platform-injected variables: `var.cc_metadata`, `var.cluster`, `var.baseinfra`
- Adds RULE-015 to `rules.md` documenting these as prohibited variables

## Changes

### Documentation
- **rules.md**: Added RULE-015 explaining prohibited variables and correct patterns using `TF_VAR_*` environment variables

### Modules Fixed

| Module | Changes |
|--------|---------|
| `prometheus/k8s_standard` | Use `data "external"` to read `TF_VAR_cc_host`, `TF_VAR_cc_auth_token`. Use `var.environment.cluster_id` |
| `k8s_callback/k8s_standard` | Use env vars directly in shell command (`$TF_VAR_cc_host`, `$TF_VAR_cc_auth_token`). Use `var.environment.cluster_id` |
| `aws/service/aws` | Build `local.cc_metadata`, `local.cluster`, `local.baseinfra` from env vars for utility module |
| `azure/service/azure` | Same approach as aws/service/aws |
| `cert_manager/standard` | Use `data "external"` to read `TF_VAR_cc_tenant_provider`, `TF_VAR_cc_region`, `TF_VAR_tenant_base_domain_id` |
| `ingress/nginx_k8s` | Use `data "external"` to read `TF_VAR_cc_tenant_provider`, `TF_VAR_tenant_base_domain`, `TF_VAR_tenant_base_domain_id` |
| `gcp/service/gcp` | Remove `var.cluster.k8sRequestsToLimitsRatio` usage entirely |

## Test plan
- [ ] Verify modules pass `raptor create iac-module --dry-run` validation
- [ ] Test deployment in a staging environment
- [ ] Confirm env vars are correctly read at runtime