### PR TITLE
Fix: Helm metadata list access in k8s_standard module

### DIFF
--- a/modules/common/helm/k8s_standard/1.0/outputs.tf
+++ b/modules/common/helm/k8s_standard/1.0/outputs.tf
@@ -1,7 +1,7 @@
 locals {
   output_attributes = {
     release_name = helm_release.external_helm_charts.name
-    values       = jsondecode(helm_release.external_helm_charts.metadata.values)
+    values       = jsondecode(helm_release.external_helm_charts.metadata[0].values)
   }
   output_interfaces = {}
 }


### PR DESCRIPTION
## Summary

Fixed Terraform error when deploying Helm charts using the `helm/k8s_standard/1.0` module. The module was attempting to access `helm_release.external_helm_charts.metadata.values` as a single object, but the Helm provider returns `metadata` as a list.

## Problem

Helm releases were failing with this error:
```
Error: Unsupported attribute
on .terraform/modules/level2.helm_open-cost/outputs.tf line 4, in locals:
4: values = jsondecode(helm_release.external_helm_charts.metadata.values)
Can't access attributes on a list of objects. Did you mean to access
attribute "values" for a specific element of the list, or across all
elements of the list?
```

**Failed Release:** [opencost deployment](https://1155708878.control-plane-saas-cp-saas-dev.console.facets.cloud/capc/stack/multi-cloud-test-1155708878/releases/cluster/6964c9a29b07442a521b88ff/dialog/release-details/6969f9c57751a84d9201e061)

## Changes

**File:** `modules/common/helm/k8s_standard/1.0/outputs.tf`

```diff
- values = jsondecode(helm_release.external_helm_charts.metadata.values)
+ values = jsondecode(helm_release.external_helm_charts.metadata[0].values)
```

## Why This Works

- The Terraform Helm provider returns `metadata` as a **list**, even for single resources
- This module creates exactly one Helm release per instance (no `count` or `for_each`)
- Accessing `metadata[0]` gets the first (and only) element in the list
- This pattern is already used correctly in `eck-operator` and `strimzi-operator` modules

## Impact

✅ **Safe Change** - No existing resources will be affected:
- Only fixes output computation (doesn't modify deployed resources)
- No Helm releases will be recreated or redeployed
- The original code was broken and couldn't execute
- Downstream modules get the same data structure, just computed correctly

## Test Plan

- [x] Verify terraform plan succeeds for helm modules
- [x] Deploy a test Helm chart (e.g., opencost) and confirm successful deployment
- [x] Verify output attributes are correctly populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)