### PR TITLE
Fix Non-existent Module Reference in GCP Project Type

### DIFF
--- a/project-type/gcp/base/kubernetes_node_pool/instances/nodepool.json
+++ b/project-type/gcp/base/kubernetes_node_pool/instances/nodepool.json
@@ -1,5 +1,5 @@
 {
-  "flavor": "gke_custom_node_pool",
+  "flavor": "gcp",
   "version": "1.0",
   "kind": "kubernetes_node_pool",
   "metadata": {},

--- a/project-type/gcp/project-type.yml
+++ b/project-type/gcp/project-type.yml
@@ -14,7 +14,7 @@ modules:
     - intent: kubernetes_cluster
       flavor: gke
     - intent: kubernetes_node_pool
-      flavor: gke_custom_node_pool
+      flavor: gcp
     - intent: kubernetes_node_pool
       flavor: gcp_node_fleet
     - intent: network


### PR DESCRIPTION
 ### Summary                                                                                                                                               
  Fixed references to non-existent `gke_custom_node_pool` flavor by updating to the correct `gcp` flavor.                                                   
                                                                                                                                                            
  ### Changes                                                                                                                                               
  - Updated `project-type/gcp/project-type.yml` line 17: `gke_custom_node_pool` → `gcp`                                                                     
  - Updated `project-type/gcp/base/kubernetes_node_pool/instances/nodepool.json` line 2: flavor changed to `gcp`                                            
                                                                                                                                                            
  ### Details                                                                                                                                               
  The GCP project-type configuration referenced `kubernetes_node_pool/gke_custom_node_pool` which doesn't exist in the codebase. The correct flavor is      
  `gcp`, which provides custom GKE node pool functionality with advanced configuration options (instance types, autoscaling, spot instances, taints, labels,
   etc.).                                                                                                                                                   
                                                                                                                                                            
  **Available kubernetes_node_pool flavors:**                                                                                                               
  - `aws` - AWS EKS node pools                                                                                                                              
  - `azure` - Azure AKS node pools                                                                                                                          
  - `gcp` - Custom GKE node pools (single pool)                                                                                                             
  - `gcp_node_fleet` - GKE node fleet (multiple pools) ✅ Already correct                                                                                   
                                                                                                                                                            
  ### Verification                                                                                                                                          
  - [x] No remaining references to `gke_custom_node_pool` in codebase                                                                                        
  - [x] `gcp` flavor exists and matches the nodepool.json spec structure                                                                                     
  - [x] `gcp_node_fleet` reference in nodepool-fleet.json is already correct  