### PR TITLE
Add @facets/karpenter-details output type schema

### DIFF
--- a/outputs/karpenter-details/outputs.yaml
+++ b/outputs/karpenter-details/outputs.yaml
@@ -1,0 +1,29 @@
+name: '@facets/karpenter-details'
+properties:
+  type: object
+  properties:
+    attributes:
+      type: object
+      properties:
+        karpenter_namespace:
+          type: string
+        karpenter_service_account:
+          type: string
+        karpenter_version:
+          type: string
+        controller_role_arn:
+          type: string
+        node_role_arn:
+          type: string
+        node_instance_profile_name:
+          type: string
+        interruption_queue_name:
+          type: string
+        secrets:
+          type: array
+          items:
+            type: string
+    interfaces:
+      type: object
+      properties: {}
+providers: []


### PR DESCRIPTION
## Summary
- Add output type schema for `@facets/karpenter-details`
- Schema includes attributes for karpenter namespace, service account, version, IAM roles, instance profile, and interruption queue

## Test plan
- [x] Output type published successfully with raptor
- [x] Karpenter module uploaded and published successfully