### PR TITLE
Add missing intentDetails UI metadata to modules

### DIFF
--- a/aws/kubernetes_cluster/eks/1.0/facets.yaml
+++ b/aws/kubernetes_cluster/eks/1.0/facets.yaml
@@ -8,6 +8,10 @@ clouds:
 title: EKS Cluster with Auto Mode support
 description: A Kubernetes EKS cluster module with auto mode enabled by default and
   all necessary configurations preset.
+intentDetails:
+  type: kubernetes
+  description: AWS EKS cluster with auto mode enabled and all necessary configurations preset
+  displayName: EKS
 inputs:
   network_details:
     type: '@facets/aws-vpc-details'

--- a/aws/network/aws_vpc/1.0/facets.yaml
+++ b/aws/network/aws_vpc/1.0/facets.yaml
@@ -6,6 +6,10 @@ description: Creates a Kubernetes-optimized AWS VPC with auto-calculated subnets
   Database (256 IPs/AZ)
 clouds:
 - aws
+intentDetails:
+  type: networking
+  description: Kubernetes-optimized AWS VPC with auto-calculated subnets across availability zones
+  displayName: AWS Network
 spec:
   type: object
   properties:

--- a/azure/kubernetes_cluster/aks/1.0/facets.yaml
+++ b/azure/kubernetes_cluster/aks/1.0/facets.yaml
@@ -6,6 +6,10 @@ clouds:
 title: AKS Cluster with Auto-Upgrade Support
 description: A Kubernetes AKS cluster module with auto-upgrade enabled by default
   and all necessary configurations preset.
+intentDetails:
+  type: kubernetes
+  description: Azure AKS cluster with auto-upgrade enabled and all necessary configurations preset
+  displayName: AKS
 allow_skipping_module_on_selective_release: false
 spec:
   type: object

--- a/azure/network/azure_network/1.0/facets.yaml
+++ b/azure/network/azure_network/1.0/facets.yaml
@@ -6,6 +6,10 @@ description: Creates an Azure Virtual Network with automatically calculated subn
   and MySQL Flexible Servers
 clouds:
 - azure
+intentDetails:
+  type: networking
+  description: Azure Virtual Network with auto-calculated subnets and database delegation support
+  displayName: Azure Network
 inputs:
   cloud_account:
     type: '@facets/azure_cloud_account'

--- a/common/artifactory/standard/1.0/facets.yaml
+++ b/common/artifactory/standard/1.0/facets.yaml
@@ -7,6 +7,10 @@ clouds:
 - kubernetes
 - azure
 - aws
+intentDetails:
+  type: storage
+  description: Manages container registry secrets for pulling images from artifactories
+  displayName: Artifactories
 inputs:
   kubernetes_details:
     optional: false

--- a/common/cert_manager/standard/1.0/facets.yaml
+++ b/common/cert_manager/standard/1.0/facets.yaml
@@ -2,6 +2,10 @@ intent: cert_manager
 flavor: standard
 version: '1.0'
 description: Deploys Cert Manager for managing ssl certificates
+intentDetails:
+  type: security
+  description: Deploys Cert Manager for automated SSL/TLS certificate management in Kubernetes
+  displayName: Cert Manager
 clouds:
 - aws
 - azure

--- a/common/eck-operator/helm/1.0/facets.yaml
+++ b/common/eck-operator/helm/1.0/facets.yaml
@@ -4,6 +4,10 @@ version: '1.0'
 clouds:
 - kubernetes
 description: Elastic Cloud on Kubernetes (ECK) Operator deployed via Helm chart
+intentDetails:
+  type: operator
+  description: Elastic Cloud on Kubernetes (ECK) Operator for managing Elasticsearch clusters
+  displayName: ECK Operator
 spec:
   title: ECK Operator
   description: Installs and manages the ECK Operator using Helm

--- a/common/grafana_dashboards/k8s/1.0/facets.yaml
+++ b/common/grafana_dashboards/k8s/1.0/facets.yaml
@@ -5,6 +5,10 @@ clouds:
     - kubernetes
 description: Deploy Grafana dashboards as ConfigMaps with auto-discovery labels. Paste dashboard JSON exported from Grafana.
 flavor: k8s
+intentDetails:
+    type: monitoring
+    description: Deploy Grafana dashboards as ConfigMaps with auto-discovery labels
+    displayName: Grafana Dashboards
 inputs:
     kubernetes_details:
         displayName: Kubernetes Cluster

--- a/common/k8s_callback/k8s_standard/1.0/facets.yaml
+++ b/common/k8s_callback/k8s_standard/1.0/facets.yaml
@@ -3,6 +3,10 @@ flavor: k8s_standard
 version: '1.0'
 description: Creates ServiceAccount with admin role and registers OVH K8s credentials
   with Facets control plane
+intentDetails:
+  type: kubernetes
+  description: Creates ServiceAccount with admin role and registers K8s credentials with Facets control plane
+  displayName: K8s Callback
 clouds:
 - kubernetes
 inputs:

--- a/common/prometheus/k8s_standard/1.0/facets.yaml
+++ b/common/prometheus/k8s_standard/1.0/facets.yaml
@@ -3,6 +3,10 @@ flavor: k8s_standard
 version: '1.0'
 description: Prometheus monitoring stack for Kubernetes with Grafana, Alertmanager,
   and kube-state-metrics
+intentDetails:
+  type: monitoring
+  description: Prometheus monitoring stack for Kubernetes with Grafana and Alertmanager
+  displayName: Prometheus
 clouds:
 - aws
 - azure

--- a/common/strimzi-operator/helm/1.0/facets.yaml
+++ b/common/strimzi-operator/helm/1.0/facets.yaml
@@ -5,6 +5,10 @@ clouds:
 - kubernetes
 description: Strimzi Kafka Operator deployed via Helm chart for managing Kafka clusters
   on Kubernetes
+intentDetails:
+  type: operator
+  description: Strimzi Kafka Operator for managing Apache Kafka clusters on Kubernetes
+  displayName: Strimzi Operator
 spec:
   title: Strimzi Kafka Operator
   description: Installs and manages the Strimzi Operator using Helm for Apache Kafka

--- a/common/vpa/standard/1.0/facets.yaml
+++ b/common/vpa/standard/1.0/facets.yaml
@@ -3,6 +3,10 @@ flavor: standard
 version: '1.0'
 description: Deploys Vertical Pod Autoscaler (VPA) for automatic resource recommendations
   and right-sizing
+intentDetails:
+  type: autoscaling
+  description: Vertical Pod Autoscaler for automatic resource recommendations and right-sizing
+  displayName: VPA
 clouds:
 - aws
 - azure

--- a/gcp/kubernetes_cluster/gke/1.0/facets.yaml
+++ b/gcp/kubernetes_cluster/gke/1.0/facets.yaml
@@ -6,6 +6,10 @@ clouds:
 title: GKE Cluster Control Plane
 description: Creates a GKE cluster control plane without default node pool. Use kubernetes_node_pool
   module to add node pools.
+intentDetails:
+  type: kubernetes
+  description: GKE cluster control plane without default node pool for flexible node management
+  displayName: GKE
 spec:
   type: object
   properties:

--- a/gcp/network/gcp_vpc/1.0/facets.yaml
+++ b/gcp/network/gcp_vpc/1.0/facets.yaml
@@ -3,6 +3,10 @@ clouds:
 description: Creates a GKE-optimized GCP VPC with auto-calculated subnets. Fixed allocation
   - Private (8K IPs), Public (256 IPs), Database (256 IPs), plus GKE secondary ranges
 flavor: gcp-vpc
+intentDetails:
+  type: networking
+  description: GKE-optimized GCP VPC with auto-calculated subnets and GKE secondary ranges
+  displayName: GCP Network
 iac:
   validated_files:
   - main.tf


### PR DESCRIPTION
## Summary
- Adds `intentDetails` UI metadata (type, description, displayName) to 14 modules that were missing this configuration
- This enables proper rendering of these resource types in the Facets UI

Fixes #153

## Changes

### Common Modules (8 files):
- `common/cert_manager/standard/1.0` - type: security
- `common/eck-operator/helm/1.0` - type: operator
- `common/grafana_dashboards/k8s/1.0` - type: monitoring
- `common/k8s_callback/k8s_standard/1.0` - type: kubernetes
- `common/prometheus/k8s_standard/1.0` - type: monitoring
- `common/strimzi-operator/helm/1.0` - type: operator
- `common/vpa/standard/1.0` - type: autoscaling
- `common/artifactory/standard/1.0` - type: storage

### Kubernetes Cluster Modules (3 files):
- `aws/kubernetes_cluster/eks/1.0` - type: kubernetes
- `azure/kubernetes_cluster/aks/1.0` - type: kubernetes
- `gcp/kubernetes_cluster/gke/1.0` - type: kubernetes

### Network Modules (3 files):
- `aws/network/aws_vpc/1.0` - type: networking
- `azure/network/azure_network/1.0` - type: networking
- `gcp/network/gcp_vpc/1.0` - type: networking

## Test plan
- [ ] Verify modules render correctly in Facets UI with new metadata
- [ ] Run `raptor create iac-module -f <module-path> --dry-run` validation passes for metadata section