### PR TITLE
Replace deprecated Kubernetes Terraform resources with _v1 versions

### DIFF
--- a/aws/kubernetes_cluster/eks/1.0/aws-terraform-eks/modules/aws-auth/main.tf
+++ b/aws/kubernetes_cluster/eks/1.0/aws-terraform-eks/modules/aws-auth/main.tf
@@ -11,7 +11,7 @@ locals {
   }
 }
 
-resource "kubernetes_config_map" "aws_auth" {
+resource "kubernetes_config_map_v1" "aws_auth" {
   count = var.create && var.create_aws_auth_configmap ? 1 : 0
 
   metadata {
@@ -42,6 +42,6 @@ resource "kubernetes_config_map_v1_data" "aws_auth" {
 
   depends_on = [
     # Required for instances where the configmap does not exist yet to avoid race condition
-    kubernetes_config_map.aws_auth,
+    kubernetes_config_map_v1.aws_auth,
   ]
 }

--- a/azure/azure_workload_identity/azure/1.0/main.tf
+++ b/azure/azure_workload_identity/azure/1.0/main.tf
@@ -17,7 +17,7 @@ resource "azurerm_user_assigned_identity" "main" {
 }
 
 # Kubernetes Service Account with workload identity annotation
-resource "kubernetes_service_account" "main" {
+resource "kubernetes_service_account_v1" "main" {
   count = local.use_existing_k8s_sa ? 0 : 1
 
   automount_service_account_token = local.automount_service_account_token
@@ -52,7 +52,7 @@ resource "azurerm_federated_identity_credential" "main" {
   depends_on = [
     azurerm_user_assigned_identity.main,
     data.azurerm_user_assigned_identity.existing,
-    kubernetes_service_account.main
+    kubernetes_service_account_v1.main
   ]
 }
 

--- a/common/artifactory/standard/1.0/ecr-token-refresher.tf
+++ b/common/artifactory/standard/1.0/ecr-token-refresher.tf
@@ -65,7 +65,7 @@ resource "kubernetes_cron_job_v1" "ecr-token-refresher-cron" {
                 effect   = lookup(toleration.value, "effect", null)
               }
             }
-            service_account_name            = kubernetes_service_account.ecr-token-refresher-sa[each.key].metadata.0.name
+            service_account_name            = kubernetes_service_account_v1.ecr-token-refresher-sa[each.key].metadata.0.name
             automount_service_account_token = true
             node_selector                   = local.node_selector
             container {
@@ -162,7 +162,7 @@ resource "kubernetes_role_v1" "ecr-token-refresher-role" {
   }
 }
 
-resource "kubernetes_service_account" "ecr-token-refresher-sa" {
+resource "kubernetes_service_account_v1" "ecr-token-refresher-sa" {
   for_each = local.artifactories_ecr
   metadata {
     name      = module.name[each.key].name
@@ -183,7 +183,7 @@ resource "kubernetes_role_binding_v1" "ecr-token-refresher-crb" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.ecr-token-refresher-sa[each.key].metadata.0.name
+    name      = kubernetes_service_account_v1.ecr-token-refresher-sa[each.key].metadata.0.name
     namespace = local.namespace
   }
 }
@@ -220,7 +220,7 @@ resource "kubernetes_job_v1" "ecr-token-refresher-initial" {
             effect   = lookup(toleration.value, "effect", null)
           }
         }
-        service_account_name            = kubernetes_service_account.ecr-token-refresher-sa[each.key].metadata.0.name
+        service_account_name            = kubernetes_service_account_v1.ecr-token-refresher-sa[each.key].metadata.0.name
         automount_service_account_token = true
         node_selector                   = local.node_selector
         container {

--- a/common/grafana_dashboards/k8s/1.0/main.tf
+++ b/common/grafana_dashboards/k8s/1.0/main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 # Create ConfigMap for each dashboard with Grafana auto-discovery labels
-resource "kubernetes_config_map" "grafana_dashboard" {
+resource "kubernetes_config_map_v1" "grafana_dashboard" {
   for_each = local.dashboards
 
   metadata {

--- a/common/ingress/nginx_k8s/1.0/main.tf
+++ b/common/ingress/nginx_k8s/1.0/main.tf
@@ -142,7 +142,7 @@ locals {
   additional_ingress_annotations_with_auth = merge(
     lookup(var.instance.spec, "basicAuth", lookup(var.instance.spec, "basic_auth", false)) ? {
       "nginx.ingress.kubernetes.io/auth-realm" : "Authentication required"
-      "nginx.ingress.kubernetes.io/auth-secret" : length(kubernetes_secret.ingress-auth) > 0 ? kubernetes_secret.ingress-auth[0].metadata[0].name : ""
+      "nginx.ingress.kubernetes.io/auth-secret" : length(kubernetes_secret_v1.ingress-auth) > 0 ? kubernetes_secret_v1.ingress-auth[0].metadata[0].name : ""
       "nginx.ingress.kubernetes.io/auth-type" : "basic"
     } : {}
   )
@@ -430,7 +430,7 @@ VALUES
 }
 
 # secret with the auth details
-resource "kubernetes_secret" "ingress-auth" {
+resource "kubernetes_secret_v1" "ingress-auth" {
   count = lookup(var.instance.spec, "basicAuth", lookup(var.instance.spec, "basic_auth", false)) ? 1 : 0
   metadata {
     name      = "${var.instance_name}-nginx-ingress-auth"
@@ -834,7 +834,7 @@ module "custom_error_pages_configmap" {
   }
 }
 
-resource "kubernetes_secret" "custom_tls" {
+resource "kubernetes_secret_v1" "custom_tls" {
   for_each = local.custom_tls_domains
 
   metadata {

--- a/common/k8s_callback/k8s_standard/1.0/main.tf
+++ b/common/k8s_callback/k8s_standard/1.0/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 # Create ServiceAccount
-resource "kubernetes_service_account" "facets_admin" {
+resource "kubernetes_service_account_v1" "facets_admin" {
   metadata {
     name      = local.service_account_name
     namespace = local.namespace
@@ -12,7 +12,7 @@ resource "kubernetes_service_account" "facets_admin" {
 }
 
 # Create ClusterRoleBinding for admin access
-resource "kubernetes_cluster_role_binding" "facets_admin" {
+resource "kubernetes_cluster_role_binding_v1" "facets_admin" {
   metadata {
     name = "${local.service_account_name}-binding"
   }
@@ -25,18 +25,18 @@ resource "kubernetes_cluster_role_binding" "facets_admin" {
 
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.facets_admin.metadata[0].name
-    namespace = kubernetes_service_account.facets_admin.metadata[0].namespace
+    name      = kubernetes_service_account_v1.facets_admin.metadata[0].name
+    namespace = kubernetes_service_account_v1.facets_admin.metadata[0].namespace
   }
 }
 
 # Create a secret for the service account token
-resource "kubernetes_secret" "facets_admin_token" {
+resource "kubernetes_secret_v1" "facets_admin_token" {
   metadata {
     name      = "${local.service_account_name}-token"
     namespace = local.namespace
     annotations = {
-      "kubernetes.io/service-account.name" = kubernetes_service_account.facets_admin.metadata[0].name
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.facets_admin.metadata[0].name
     }
   }
 
@@ -44,15 +44,15 @@ resource "kubernetes_secret" "facets_admin_token" {
   wait_for_service_account_token = true
 
   depends_on = [
-    kubernetes_service_account.facets_admin
+    kubernetes_service_account_v1.facets_admin
   ]
 }
 
 # Extract the token after it's generated
 data "kubernetes_secret" "facets_admin_token" {
   metadata {
-    name      = kubernetes_secret.facets_admin_token.metadata[0].name
-    namespace = kubernetes_secret.facets_admin_token.metadata[0].namespace
+    name      = kubernetes_secret_v1.facets_admin_token.metadata[0].name
+    namespace = kubernetes_secret_v1.facets_admin_token.metadata[0].namespace
   }
 }
 
@@ -75,7 +75,7 @@ EOF
   }
 
   depends_on = [
-    kubernetes_cluster_role_binding.facets_admin,
+    kubernetes_cluster_role_binding_v1.facets_admin,
     data.kubernetes_secret.facets_admin_token
   ]
 }

--- a/common/vpa/standard/1.0/main.tf
+++ b/common/vpa/standard/1.0/main.tf
@@ -1,6 +1,6 @@
 # Define your terraform resources here
 
-resource "kubernetes_namespace" "vpa_namespace" {
+resource "kubernetes_namespace_v1" "vpa_namespace" {
   count = local.create_namespace ? 1 : 0
   metadata {
     name = local.vpa_namespace
@@ -28,7 +28,7 @@ resource "helm_release" "vpa" {
   recreate_pods    = local.recreate_pods
 
   depends_on = [
-    kubernetes_namespace.vpa_namespace
+    kubernetes_namespace_v1.vpa_namespace
   ]
 
   values = [

--- a/gcp/google_workload_identity/default/1.0/main.tf
+++ b/gcp/google_workload_identity/default/1.0/main.tf
@@ -25,7 +25,7 @@ resource "google_service_account" "cluster_service_account" {
   project      = local.project_id
 }
 
-resource "kubernetes_service_account" "main" {
+resource "kubernetes_service_account_v1" "main" {
   count = local.use_existing_k8s_sa ? 0 : 1
 
   automount_service_account_token = local.automount_service_account_token

--- a/gcp/service/gcp/1.0/gcp_workload-identity/workload-identity/main.tf
+++ b/gcp/service/gcp/1.0/gcp_workload-identity/workload-identity/main.tf
@@ -26,8 +26,8 @@ locals {
 
   # This will cause Terraform to block returning outputs until the service account is created
   k8s_given_name       = var.k8s_sa_name != null ? var.k8s_sa_name : var.name
-  output_k8s_name      = var.use_existing_k8s_sa ? local.k8s_given_name : kubernetes_service_account.main[0].metadata[0].name
-  output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account.main[0].metadata[0].namespace
+  output_k8s_name      = var.use_existing_k8s_sa ? local.k8s_given_name : kubernetes_service_account_v1.main[0].metadata[0].name
+  output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account_v1.main[0].metadata[0].namespace
 
   k8s_sa_project_id       = var.k8s_sa_project_id != null ? var.k8s_sa_project_id : var.project_id
   k8s_sa_gcp_derived_name = "serviceAccount:${local.k8s_sa_project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"
@@ -53,7 +53,7 @@ resource "google_service_account" "cluster_service_account" {
   }
 }
 
-resource "kubernetes_service_account" "main" {
+resource "kubernetes_service_account_v1" "main" {
   count = var.use_existing_k8s_sa ? 0 : 1
 
   automount_service_account_token = var.automount_service_account_token


### PR DESCRIPTION
## Summary
- Replaces deprecated Kubernetes provider resources with their `_v1` equivalents
- Ensures compatibility with current Terraform Kubernetes provider versions

Fixes #154

## Changes

| Resource Type | Replacement |
|--------------|-------------|
| `kubernetes_service_account` | `kubernetes_service_account_v1` |
| `kubernetes_namespace` | `kubernetes_namespace_v1` |
| `kubernetes_secret` | `kubernetes_secret_v1` |
| `kubernetes_config_map` | `kubernetes_config_map_v1` |
| `kubernetes_cluster_role_binding` | `kubernetes_cluster_role_binding_v1` |

### Files Updated (10 files):
- `azure/azure_workload_identity/azure/1.0/main.tf`
- `gcp/google_workload_identity/default/1.0/main.tf`
- `gcp/service/gcp/1.0/gcp_workload-identity/workload-identity/main.tf`
- `common/cert_manager/standard/1.0/main.tf`
- `common/ingress/nginx_k8s/1.0/main.tf`
- `common/artifactory/standard/1.0/ecr-token-refresher.tf`
- `common/grafana_dashboards/k8s/1.0/main.tf`
- `common/vpa/standard/1.0/main.tf`
- `common/k8s_callback/k8s_standard/1.0/main.tf`
- `aws/kubernetes_cluster/eks/1.0/aws-terraform-eks/modules/aws-auth/main.tf`

## Test plan
- [ ] Run `raptor create iac-module -f <module-path> --dry-run` to verify no deprecated resource warnings
- [ ] Verify Terraform plan/apply works with updated resources