### PR TITLE
Fix Prometheus module configuration and improve values structure

### DIFF
--- a/modules/common/prometheus/k8s_standard/1.0/locals.tf
+++ b/modules/common/prometheus/k8s_standard/1.0/locals.tf
@@ -358,19 +358,21 @@ locals {
       enabled = lookup(local.kubeStateMetricsSpec, "enabled", true)
       collectors = distinct(concat([
         "certificatesigningrequests", "configmaps", "cronjobs", "daemonsets", "deployments",
-        "endpoints", "horizontalpodautoscalers", "verticalpodautoscalers", "ingresses", "jobs",
+        "endpoints", "horizontalpodautoscalers", "ingresses", "jobs",
         "leases", "limitranges", "mutatingwebhookconfigurations", "namespaces", "networkpolicies",
         "nodes", "persistentvolumeclaims", "persistentvolumes", "poddisruptionbudgets", "pods",
         "replicasets", "replicationcontrollers", "resourcequotas", "secrets", "services",
         "statefulsets", "storageclasses", "validatingwebhookconfigurations", "volumeattachments"
       ], lookup(local.kubeStateMetricsSpec, "collectors", [])))
       extraArgs = [
-        "--metric-labels-allowlist=pods=[*],nodes=[*],ingresses=[*]",
-        "--resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments"
+        "--metric-labels-allowlist=pods=[*],nodes=[*],ingresses=[*]"
       ]
       # priorityClassName = "facets-critical"
       nodeSelector = local.nodeSelector
       tolerations  = local.tolerations
+      rbac = {
+        extraRules = []
+      }
     }
     "prometheus-node-exporter" = {
       nodeSelector = {

--- a/modules/common/prometheus/k8s_standard/1.0/main.tf
+++ b/modules/common/prometheus/k8s_standard/1.0/main.tf
@@ -20,60 +20,59 @@ resource "helm_release" "prometheus-operator" {
   cleanup_on_fail = true
 
   values = [
-    yamlencode(merge(
-      local.default_values,
-      {
-        prometheus = {
-          prometheusSpec = {
-            storageSpec = {
-              volumeClaimTemplate = {
-                metadata = {
-                  name = "pvc"
-                }
-                spec = {
-                  # Use existing PVC
-                  # volumeName  = module.prometheus-pvc.pvc_name
-                  volumeName  = "pvc"
-                  accessModes = ["ReadWriteOnce"]
-                  resources = {
-                    requests = {
-                      storage = lookup(local.prometheusSpec.size, "volume", "100Gi")
-                    }
+    yamlencode(local.default_values),
+    yamlencode({
+      prometheus = {
+        prometheusSpec = {
+          storageSpec = {
+            volumeClaimTemplate = {
+              metadata = {
+                name = "pvc"
+              }
+              spec = {
+                # Use existing PVC
+                # volumeName  = module.prometheus-pvc.pvc_name
+                volumeName  = "pvc"
+                accessModes = ["ReadWriteOnce"]
+                resources = {
+                  requests = {
+                    storage = lookup(local.prometheusSpec.size, "volume", "100Gi")
                   }
                 }
               }
             }
           }
-        },
-        alertmanager = {
-          alertmanagerSpec = {
-            storage = {
-              volumeClaimTemplate = {
-                metadata = {
-                  name = "pvc"
-                }
-                spec = {
-                  # Use existing PVC
-                  # volumeName  = module.alertmanager-pvc.pvc_name
-                  volumeName  = "pvc"
-                  accessModes = ["ReadWriteOnce"]
-                  resources = {
-                    requests = {
-                      storage = lookup(local.alertmanagerSpec.size, "volume", "10Gi")
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        kube-state-metrics = {
-          enabled = true
         }
       },
-      local.valuesSpec,         # User's custom values (other than alertmanager.config)
-      local.alertmanager_config # Alertmanager config with concatenated receivers
-    ))
+      alertmanager = {
+        alertmanagerSpec = {
+          storage = {
+            volumeClaimTemplate = {
+              metadata = {
+                name = "pvc"
+              }
+              spec = {
+                # Use existing PVC
+                # volumeName  = module.alertmanager-pvc.pvc_name
+                volumeName  = "pvc"
+                accessModes = ["ReadWriteOnce"]
+                resources = {
+                  requests = {
+                    storage = lookup(local.alertmanagerSpec.size, "volume", "10Gi")
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      kube-state-metrics = {
+        enabled = true
+      }
+    }),
+    yamlencode(local.valuesSpec),         # User's custom values (other than alertmanager.config)
+    yamlencode(local.alertmanager_config) # Alertmanager config with concatenated receivers
+
   ]
 }
 


### PR DESCRIPTION
## Summary
This PR addresses configuration issues in the Prometheus Helm chart deployment and refactors the values structure for better maintainability.

## Changes

### Kube-State-Metrics Configuration
- **Removed** `verticalpodautoscalers` from the default collectors list
- **Removed** the `--resources` extra argument to simplify configuration
- **Added** empty `rbac.extraRules` configuration for future extensibility

### Helm Values Structure
- **Refactored** values configuration to use separate `yamlencode()` calls for each configuration block
- **Improved** readability by separating:
  - Default values
  - Storage configuration (Prometheus & Alertmanager)
  - Kube-state-metrics enablement
  - User custom values
  - Alertmanager config

### Benefits
- More maintainable and cleaner configuration structure
- Fixes potential conflicts from merged YAML encoding
- Better separation of concerns between default, storage, and user-provided values