### PR TITLE
Remove alias-flavors from eks_automode sample

### DIFF
--- a/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
@@ -178,8 +178,6 @@ spec:
 sample:
   kind: kubernetes_cluster
   flavor: eks_automode
-  alias-flavors:
-    - default
   version: '1.0'
   metadata:
     name: eks-cluster


### PR DESCRIPTION
## Summary
- Remove unnecessary `alias-flavors` field from the eks_automode sample configuration

## Test plan
- [ ] Verify module validation passes with `raptor create iac-module -f modules/kubernetes_cluster/eks_automode/1.0 --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)