### PR TITLE
Add disk_type to GCP node pool spec

### DIFF
--- a/modules/kubernetes_node_pool/gcp/1.0/facets.yaml
+++ b/modules/kubernetes_node_pool/gcp/1.0/facets.yaml
@@ -80,6 +80,15 @@ spec:
       type: integer
       minimum: 50
       maximum: 1000
+    disk_type:
+      title: Disk Type
+      description: Type of the disk attached to each node in the node pool
+      type: string
+      enum:
+        - pd-standard
+        - pd-ssd
+        - pd-balanced
+      default: pd-standard
     taints:
       title: Taints
       description: Array of Kubernetes taints which should be applied to nodes in the node pool. Enter array of object in YAML format.
@@ -148,6 +157,7 @@ sample:
     min_node_count: 1
     max_node_count: 20
     disk_size: 100
+    disk_type: pd-standard
     single_az: false
     spot: false
     taints: []

--- a/modules/kubernetes_node_pool/gcp/1.0/variables.tf
+++ b/modules/kubernetes_node_pool/gcp/1.0/variables.tf
@@ -6,6 +6,7 @@ variable "instance" {
       min_node_count = 1
       max_node_count = 1
       disk_size      = 100
+      disk_type      = "pd-standard"
       taints         = []
       labels         = {}
     }


### PR DESCRIPTION
## Summary
- Added `disk_type` property to the GCP node pool `facets.yaml` spec with enum values: `pd-standard`, `pd-ssd`, `pd-balanced` (default: `pd-standard`)
- Updated `variables.tf` default to include `disk_type`
- Updated `sample` section to include `disk_type`
- The field was already consumed in `main.tf` via `lookup(local.spec, "disk_type", "pd-standard")` but was not exposed in the spec, making it impossible for users to configure

## Test plan
- [ ] Run `raptor create iac-module -f modules/kubernetes_node_pool/gcp/1.0 --dry-run` to validate
- [ ] Verify node pool creation with each disk type option