### PR TITLE
Remove managed_node_groups from eks_standard module, keep only default node pool

### DIFF
--- a/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
@@ -85,7 +85,7 @@ sample:
         enable_cluster_encryption: false
     version: "1.0"
 spec:
-    description: Configure your Amazon EKS cluster with managed node groups
+    description: Configure your Amazon EKS cluster with a default system node pool. Additional node pools should be created using the kubernetes_node_pool resource.
     properties:
         cluster_addons:
             description: Managed EKS add-ons configuration
@@ -270,65 +270,6 @@ spec:
             description: Enable encryption of Kubernetes secrets using AWS KMS
             title: Enable Secrets Encryption
             type: boolean
-        managed_node_groups:
-            description: Configure managed node groups for the EKS cluster
-            patternProperties:
-                ^[a-zA-Z0-9_-]+$:
-                    properties:
-                        capacity_type:
-                            default: ON_DEMAND
-                            description: Type of capacity for the node group
-                            enum:
-                                - ON_DEMAND
-                                - SPOT
-                            title: Capacity Type
-                            type: string
-                        desired_size:
-                            default: 2
-                            description: Desired number of nodes
-                            minimum: 1
-                            title: Desired Size
-                            type: integer
-                        disk_size:
-                            default: 50
-                            description: Disk size in GB for worker nodes
-                            maximum: 1000
-                            minimum: 20
-                            title: Disk Size (GB)
-                            type: integer
-                        instance_types:
-                            default:
-                                - t3.medium
-                            description: List of EC2 instance types for the node group
-                            items:
-                                type: string
-                            title: Instance Types
-                            type: array
-                        labels:
-                            description: Kubernetes labels to apply to nodes
-                            title: Node Labels
-                            type: object
-                            x-ui-yaml-editor: true
-                        max_size:
-                            default: 10
-                            description: Maximum number of nodes
-                            minimum: 1
-                            title: Maximum Size
-                            type: integer
-                        min_size:
-                            default: 1
-                            description: Minimum number of nodes
-                            minimum: 0
-                            title: Minimum Size
-                            type: integer
-                        taints:
-                            description: Kubernetes taints to apply to nodes
-                            title: Node Taints
-                            type: object
-                            x-ui-yaml-editor: true
-                    type: object
-            title: Managed Node Groups
-            type: object
     required:
         - cluster_version
     title: EKS Cluster Configuration
@@ -340,6 +281,5 @@ spec:
         - enable_cluster_encryption
         - cluster_addons
         - default_node_pool
-        - managed_node_groups
         - cluster_tags
 version: "1.0"


### PR DESCRIPTION
## Summary
- Removed `managed_node_groups` spec and logic from the `eks_standard` module so it only creates the default system node pool
- Additional node pools should now be created using the `kubernetes_node_pool` resource instead of being defined inline in the EKS cluster module
- Updated `facets.yaml` spec description and removed the `managed_node_groups` schema/UI configuration

Closes #178

## Test plan
- [ ] Verify that deploying an EKS cluster with the updated module creates only the default system node pool
- [ ] Verify that additional node pools can be created using the `kubernetes_node_pool/aws` resource
- [ ] Confirm no regressions in cluster provisioning (addons, outputs, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)