### PR TITLE
Fix: Azure AKS NSG blocks inbound HTTP/HTTPS traffic to LoadBalancer services

### DIFF
--- a/modules/network/azure_network/1.0/facets.yaml
+++ b/modules/network/azure_network/1.0/facets.yaml
@@ -1,6 +1,6 @@
 intent: network
 flavor: azure_network
-version: '1.0'
+version: '1.1'
 description: Creates an Azure Virtual Network with automatically calculated subnet
   sizes, including dedicated database subnets with proper delegation for PostgreSQL
   and MySQL Flexible Servers
@@ -94,7 +94,7 @@ outputs:
 sample:
   kind: network
   flavor: azure_network
-  version: '1.0'
+  version: '1.1'
   spec:
     vnet_cidr: 10.0.0.0/16
     region: centralindia

--- a/modules/network/azure_network/1.0/security-groups.tf
+++ b/modules/network/azure_network/1.0/security-groups.tf
@@ -21,6 +21,32 @@ resource "azurerm_network_security_group" "allow_all_default" {
     description                = "Allowing connection from within vnet"
   }
 
+  security_rule {
+    name                       = "AllowHttpInbound"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "Internet"
+    destination_address_prefix = "*"
+    description                = "Allow inbound HTTP traffic from Internet for LoadBalancer services"
+  }
+
+  security_rule {
+    name                       = "AllowHttpsInbound"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "Internet"
+    destination_address_prefix = "*"
+    description                = "Allow inbound HTTPS traffic from Internet for LoadBalancer services"
+  }
+
   tags = merge(local.common_tags, {
     Terraform = "true"
   })
@@ -33,13 +59,6 @@ resource "azurerm_network_security_group" "allow_all_default" {
 # Network Security Groups for Subnets - Apply the allow-all NSG to all subnets
 resource "azurerm_subnet_network_security_group_association" "public" {
   for_each = azurerm_subnet.public
-
-  subnet_id                 = each.value.id
-  network_security_group_id = azurerm_network_security_group.allow_all_default.id
-}
-
-resource "azurerm_subnet_network_security_group_association" "private" {
-  for_each = azurerm_subnet.private
 
   subnet_id                 = each.value.id
   network_security_group_id = azurerm_network_security_group.allow_all_default.id


### PR DESCRIPTION
## Summary

- **Remove private subnet NSG association** so AKS can manage NIC-level NSG rules for LoadBalancer services. Azure LB preserves client source IPs (internet IPs, not VNet CIDR), causing the shared NSG to block traffic to AKS nodes.
- **Add HTTP/HTTPS inbound rules** to the `allow_all_default` NSG — these apply only to public subnets which retain the NSG association.
- **Bump module version** from 1.0 to 1.1.

## Problem

The `allow_all_default` NSG was associated with both public and private subnets but only allowed inbound from VNet CIDR. Azure LoadBalancer preserves the original client source IP, so traffic arriving at AKS nodes in private subnets had internet source IPs that were blocked by the NSG.

## Approach

| Subnet Type | NSG Associated | Internet Inbound | AKS LB Works |
|-------------|---------------|-----------------|---------------|
| **Public** | Yes (`allow_all_default` with HTTP/HTTPS rules) | Ports 80/443 allowed | N/A |
| **Private** | **No** (removed) | Controlled by NIC-level NSG | **Yes** — AKS manages rules |
| **Database** | Yes (database NSG, VNet-only) | Blocked | N/A |

## Test plan

- [x] Dry-run validation passed (`raptor create iac-module --dry-run`)
- [x] Module uploaded and published as `0.1-local`
- [x] Plan confirmed: 3 private NSG associations destroyed, public NSG unchanged
- [x] Applied to `azure` env in `multi-cloud-test` project — release SUCCEEDED
- [ ] Verify AKS LoadBalancer services are reachable from internet

Closes #179