### PR TITLE
Lifecycle removal from datastore modules (kubeblocks-flavor)

### DIFF
--- a/modules/datastore/mongo/kubeblocks/1.0/main.tf
+++ b/modules/datastore/mongo/kubeblocks/1.0/main.tf
@@ -154,10 +154,6 @@ module "mongodb_cluster" {
     cleanup_on_fail = true
     max_history     = 3
   }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 # PodDisruptionBudget for MongoDB HA

--- a/modules/datastore/mysql/kubeblocks/1.0/main.tf
+++ b/modules/datastore/mysql/kubeblocks/1.0/main.tf
@@ -153,10 +153,6 @@ module "mysql_cluster" {
     cleanup_on_fail = true
     max_history     = 3
   }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 # Read-Only Service (only for replication mode)

--- a/modules/datastore/postgres/kubeblocks/1.0/main.tf
+++ b/modules/datastore/postgres/kubeblocks/1.0/main.tf
@@ -154,10 +154,6 @@ module "postgresql_cluster" {
     cleanup_on_fail = true
     max_history     = 3
   }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 # Read-Only Service (only for replication mode)

--- a/modules/datastore/redis/kubeblocks/1.0/main.tf
+++ b/modules/datastore/redis/kubeblocks/1.0/main.tf
@@ -301,10 +301,6 @@ module "redis_cluster" {
     cleanup_on_fail = true
     max_history     = 3
   }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 # Read-Only Service (only for replication mode with Sentinel)


### PR DESCRIPTION
Terraform does NOT support lifecycle blocks inside module blocks. This is a Terraform restriction. 