### PR TITLE
enable access logs by default with upstream service name

### DIFF
--- a/modules/common/ingress/nginx_gateway_fabric/1.0/main.tf
+++ b/modules/common/ingress/nginx_gateway_fabric/1.0/main.tf
@@ -861,7 +861,7 @@ resource "helm_release" "nginx_gateway_fabric" {
               agentLevel = "info"
               accessLog = {
                 disable = false
-                format  = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" upstream=$upstream_addr upstream_name=$proxy_host"
+                format  = "$remote_addr - $remote_user [$time_local] \"$request\" $status $body_bytes_sent \"$http_referer\" \"$http_user_agent\" $request_length $request_time [$proxy_host] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status"
               }
             }
           }


### PR DESCRIPTION
This pr enables access log config in nginx proxy.

<img width="1361" height="192" alt="Screenshot 2026-02-06 at 3 55 21 PM" src="https://github.com/user-attachments/assets/2212a6bb-56fe-4898-9935-dbc748c5c617" />
<img width="1434" height="397" alt="Screenshot 2026-02-06 at 3 53 56 PM" src="https://github.com/user-attachments/assets/5f2ce9a3-66f8-4b43-88fa-ee796939f46a" />



