### PR TITLE
fix: address CodeRabbit review comments for nginx gateway fabric

### DIFF
--- a/modules/common/gateway_api_crd/1.0/main.tf
+++ b/modules/common/gateway_api_crd/1.0/main.tf
@@ -86,7 +86,7 @@ resource "kubernetes_job_v1" "gateway_api_crd_installer" {
 
         container {
           name    = "kubectl"
-          image   = "bitnami/kubectl:latest"
+          image   = "bitnami/kubectl:1.31.4"
           command = ["/bin/sh", "-c"]
           args = [
             # Using --server-side to avoid annotation size limit (262KB)

--- a/modules/common/ingress/nginx_gateway_fabric/1.0/main.tf
+++ b/modules/common/ingress/nginx_gateway_fabric/1.0/main.tf
@@ -502,7 +502,7 @@ locals {
       spec = {
         selector = {
           matchLabels = {
-            "app.kubernetes.io/name"     = local.helm_release_name
+            "app.kubernetes.io/name"     = "nginx-gateway-fabric"
             "app.kubernetes.io/instance" = local.helm_release_name
           }
         }
@@ -522,7 +522,7 @@ locals {
   }
 
   # ReferenceGrant resources for cross-namespace backends
-  # Allows HTTPRoutes in Gateway namespace to reference Services in other namespaces
+  # Allows HTTPRoutes and GRPCRoutes in Gateway namespace to reference Services in other namespaces
   referencegrant_resources = {
     for ns in local.cross_namespace_backends : "referencegrant-${ns}" => {
       apiVersion = "gateway.networking.k8s.io/v1beta1"
@@ -532,11 +532,18 @@ locals {
         namespace = ns
       }
       spec = {
-        from = [{
-          group     = "gateway.networking.k8s.io"
-          kind      = "HTTPRoute"
-          namespace = var.environment.namespace
-        }]
+        from = [
+          {
+            group     = "gateway.networking.k8s.io"
+            kind      = "HTTPRoute"
+            namespace = var.environment.namespace
+          },
+          {
+            group     = "gateway.networking.k8s.io"
+            kind      = "GRPCRoute"
+            namespace = var.environment.namespace
+          }
+        ]
         to = [{
           group = ""
           kind  = "Service"


### PR DESCRIPTION
## Summary
- Pin kubectl image to `1.31.4` instead of `latest` for reproducible builds
- Fix ServiceMonitor selector to use literal `"nginx-gateway-fabric"` for `app.kubernetes.io/name`
- Add GRPCRoute to ReferenceGrant for cross-namespace backend support

## Files Changed
- `modules/common/gateway_api_crd/1.0/main.tf`
- `modules/common/ingress/nginx_gateway_fabric/1.0/main.tf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)