### PR TITLE
fix: use official kubectl image for CRD installer job

### DIFF
--- a/modules/common/gateway_api_crd/1.0/main.tf
+++ b/modules/common/gateway_api_crd/1.0/main.tf
@@ -86,11 +86,11 @@ resource "kubernetes_job_v1" "gateway_api_crd_installer" {
 
         container {
           name    = "kubectl"
-          image   = "bitnami/kubectl:1.31.4"
-          command = ["/bin/sh", "-c"]
+          image   = "registry.k8s.io/kubectl:v1.31.4"
+          command = ["kubectl"]
           args = [
             # Using --server-side to avoid annotation size limit (262KB)
-            "kubectl apply --server-side -f ${local.install_url}"
+            "apply", "--server-side", "-f", local.install_url
           ]
         }
       }


### PR DESCRIPTION
## Summary
- `bitnami/kubectl:1.31.4` does not exist on Docker Hub, causing `ImagePullBackOff` on the gateway API CRD installer job
- Switched to the official distroless image `registry.k8s.io/kubectl:v1.31.4`
- Updated `command`/`args` since the distroless image has no `/bin/sh` — invokes `kubectl` directly with separate args

## Test plan
- [x] Verified manually on cluster: job completes successfully with the new image
- [ ] Confirm Terraform plan shows only the image and command change

🤖 Generated with [Claude Code](https://claude.com/claude-code)