### PR TITLE
set interruption_handling by default to false in main.tf

### DIFF
--- a/modules/karpenter/default/1.0/outputs.tf
+++ b/modules/karpenter/default/1.0/outputs.tf
@@ -11,7 +11,7 @@ locals {
     node_instance_profile_name = aws_iam_instance_profile.karpenter_node.name
 
     # Interruption handling
-    interruption_queue_name = lookup(var.instance.spec, "interruption_handling", false) ? aws_sqs_queue.karpenter_interruption[0].name : ""
+    interruption_queue_name = local.interruption_handling_enabled ? aws_sqs_queue.karpenter_interruption[0].name : ""
 
     helm_release_id = helm_release.karpenter.id
 


### PR DESCRIPTION
Updated /Users/facets/Documents/facets-modules-redesign/modules/karpenter/default/1.0/main.tf to use
   lookup() with a default value of false for interruption_handling in 5 places:

  1. Line 233: Helm release settings - interruptionQueue configuration
  2. Line 258: SQS queue resource count
  3. Line 268: SQS queue policy resource count
  4. Line 293: EventBridge rules for_each
  5. Line 329: EventBridge targets for_each

  All occurrences now use:
  lookup(var.instance.spec, "interruption_handling", false)

  This means if interruption_handling is not specified in the spec, it defaults to false, and no
  interruption handling resources (SQS queue, EventBridge rules) will be created.