### PR TITLE
Fix Terraform cycle error in kubernetes_cluster/eks module

### DIFF
--- a/aws/kubernetes_cluster/eks/1.0/main.tf
+++ b/aws/kubernetes_cluster/eks/1.0/main.tf
@@ -40,8 +40,6 @@ resource "aws_security_group_rule" "cluster_primary_sg_ingress" {
   cidr_blocks       = each.value.cidr_blocks
   description       = lookup(each.value, "description", null)
 
-  depends_on = [module.eks]
-
   lifecycle {
     precondition {
       condition     = try(module.eks.cluster_primary_security_group_id, "") != ""


### PR DESCRIPTION
## Summary
- Removed unnecessary explicit `depends_on = [module.eks]` from `aws_security_group_rule.cluster_primary_sg_ingress` in `aws/kubernetes_cluster/eks/1.0/main.tf`
- This explicit dependency caused a Terraform cycle by forcing a wait on ALL resources in the EKS module (KMS, addons, node groups), while internal module resources referenced back through the chain
- The implicit dependency via `module.eks.cluster_primary_security_group_id` and the existing `precondition` block are sufficient

Fixes #192

## Test plan
- [ ] Deploy an EKS cluster using the `kubernetes_cluster/eks` module and verify no cycle error occurs
- [ ] Verify the cluster primary security group rules are correctly applied