### PR TITLE
Fix: Service should not fail if metadata not present

### DIFF
--- a/modules/service/aws/1.0/main.tf
+++ b/modules/service/aws/1.0/main.tf
@@ -1,6 +1,7 @@
 locals {
   # Core instance spec
-  spec = lookup(var.instance, "spec", {})
+  spec     = lookup(var.instance, "spec", {})
+  metadata = lookup(var.instance, "metadata", {})
 
   aws_advanced_config   = lookup(lookup(var.instance, "advanced", {}), "aws", {})
   aws_cloud_permissions = lookup(lookup(local.spec, "cloud_permissions", {}), "aws", {})
@@ -16,12 +17,12 @@ locals {
   enable_deployment_actions  = local.enable_actions && local.spec_type == "application" ? 1 : 0
   enable_statefulset_actions = local.enable_actions && local.spec_type == "statefulset" ? 1 : 0
 
-  namespace = lookup(var.instance.metadata, "namespace", null) == null ? var.environment.namespace : var.instance.metadata.namespace
+  namespace = lookup(local.metadata, "namespace", null) == null ? var.environment.namespace : lookup(local.metadata, "namespace", var.environment.namespace)
   annotations = merge(
     local.enable_irsa ? { "eks.amazonaws.com/role-arn" = module.irsa.0.iam_role_arn } : { "iam.amazonaws.com/role" = aws_iam_role.application-role.0.arn },
-    lookup(var.instance.metadata, "annotations", {})
+    lookup(local.metadata, "annotations", {})
   )
-  labels        = lookup(var.instance.metadata, "labels", {})
+  labels        = lookup(local.metadata, "labels", {})
   name          = "${module.sr-name.name}-ar"
   resource_type = "service"
   resource_name = var.instance_name

--- a/modules/service/azure/1.0/main.tf
+++ b/modules/service/azure/1.0/main.tf
@@ -1,6 +1,7 @@
 locals {
   # Core instance spec
-  spec = lookup(var.instance, "spec", {})
+  spec     = lookup(var.instance, "spec", {})
+  metadata = lookup(var.instance, "metadata", {})
 
   azure_advanced_config     = lookup(lookup(var.instance, "advanced", {}), "azure", {})
   azure_cloud_permissions   = lookup(lookup(local.spec, "cloud_permissions", {}), "azure", {})
@@ -14,10 +15,10 @@ locals {
   enable_deployment_actions  = local.enable_actions && local.spec_type == "application" ? 1 : 0
   enable_statefulset_actions = local.enable_actions && local.spec_type == "statefulset" ? 1 : 0
 
-  namespace   = lookup(var.instance.metadata, "namespace", null) == null ? var.environment.namespace : var.instance.metadata.namespace
-  annotations = lookup(var.instance.metadata, "annotations", {})
+  namespace   = lookup(local.metadata, "namespace", null) == null ? var.environment.namespace : lookup(local.metadata, "namespace", var.environment.namespace)
+  annotations = lookup(local.metadata, "annotations", {})
   labels = merge(
-    lookup(var.instance.metadata, "labels", {}),
+    lookup(local.metadata, "labels", {}),
     length(local.iam_arns) > 0 ? { aadpodidbinding = azurerm_user_assigned_identity.service_user_iam.0.name } : {}
   )
   name          = lower(var.instance_name)

--- a/modules/service/gcp/1.0/main.tf
+++ b/modules/service/gcp/1.0/main.tf
@@ -1,6 +1,7 @@
 locals {
   # Core instance spec and platform-provided variables
-  spec = lookup(var.instance, "spec", {})
+  spec     = lookup(var.instance, "spec", {})
+  metadata = lookup(var.instance, "metadata", {})
 
   # Platform-provided variables with fallbacks for validation
   # Get project ID from cloud account input dependency
@@ -21,15 +22,15 @@ locals {
   enable_deployment_actions  = local.enable_actions && local.spec_type == "application" ? 1 : 0
   enable_statefulset_actions = local.enable_actions && local.spec_type == "statefulset" ? 1 : 0
 
-  namespace = lookup(var.instance.metadata, "namespace", null) == null ? var.environment.namespace : var.instance.metadata.namespace
+  namespace = lookup(local.metadata, "namespace", null) == null ? var.environment.namespace : lookup(local.metadata, "namespace", var.environment.namespace)
   annotations = merge(
     local.gcp_annotations,
     length(local.iam_arns) > 0 ? { "iam.gke.io/gcp-service-account" = module.gcp-workload-identity.0.gcp_service_account_email } : {},
-    lookup(var.instance.metadata, "annotations", {}),
+    lookup(local.metadata, "annotations", {}),
     local.enable_alb_backend_config ? { "cloud.google.com/backend-config" = "{\"default\": \"${lower(var.instance_name)}\"}" } : {}
   )
   roles                     = { for key, val in local.iam_arns : val.role => { role = val.role, condition = lookup(val, "condition", {}) } }
-  labels                    = lookup(var.instance.metadata, "labels", {})
+  labels                    = lookup(local.metadata, "labels", {})
   backend_config            = lookup(local.gcp_advanced_config, "backend_config", {})
   enable_alb_backend_config = lookup(local.backend_config, "enabled", false)
   runtime                   = lookup(local.spec, "runtime", {})


### PR DESCRIPTION
## Summary
- Fixes #202
- All three service module flavors (AWS, Azure, GCP) directly accessed `var.instance.metadata` for namespace, labels, and annotations, which fails when the platform does not provide metadata in the instance
- Added a safe `metadata` local using `lookup(var.instance, "metadata", {})` in each `main.tf`, then replaced all `var.instance.metadata` references with `local.metadata`

## Test plan
- [x] `raptor create iac-module --dry-run` passes for all three modules (AWS, Azure, GCP)
- [ ] Verify module works when metadata is not provided — namespace falls back to `var.environment.namespace`, labels and annotations default to `{}`
- [ ] Verify module still works when metadata IS provided with all fields