### PR TITLE
Standardize kubernetes_cluster output convention

### DIFF
--- a/modules/kubernetes_cluster/aks/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/aks/1.0/facets.yaml
@@ -293,13 +293,12 @@ inputs:
     - azapi
 outputs:
   default:
+    type: '@facets/azure_aks'
+    title: AKS Cluster Attributes
+    description: Additional AKS cluster attributes without provider configuration
+  attributes:
     type: '@facets/kubernetes-details'
     title: Kubernetes Cluster Output
-    description: The output for the Kubernetes cluster
-  attributes:
-    type: '@facets/azure_aks'
-    title: Kubernetes Cluster Output
-    description: The output for the Kubernetes cluster
     providers:
       kubernetes:
         source: hashicorp/kubernetes

--- a/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
@@ -26,6 +26,10 @@ inputs:
       - aws
 outputs:
   default:
+    type: '@facets/eks'
+    title: EKS Cluster Attributes
+    description: Additional EKS cluster attributes without provider configuration
+  attributes:
     type: '@facets/kubernetes-details'
     title: Kubernetes Cluster Output
     providers:
@@ -33,37 +37,33 @@ outputs:
         source: hashicorp/kubernetes
         version: 2.38.0
         attributes:
-          host: attributes.cluster_endpoint
-          cluster_ca_certificate: attributes.cluster_ca_certificate
+          host: cluster_endpoint
+          cluster_ca_certificate: cluster_ca_certificate
           exec:
-            api_version: attributes.kubernetes_provider_exec.api_version
-            command: attributes.kubernetes_provider_exec.command
-            args: attributes.kubernetes_provider_exec.args
+            api_version: kubernetes_provider_exec.api_version
+            command: kubernetes_provider_exec.command
+            args: kubernetes_provider_exec.args
       helm:
         source: hashicorp/helm
         version: 2.17.0
         attributes:
           kubernetes:
-            host: attributes.cluster_endpoint
-            cluster_ca_certificate: attributes.cluster_ca_certificate
+            host: cluster_endpoint
+            cluster_ca_certificate: cluster_ca_certificate
             exec:
-              api_version: attributes.kubernetes_provider_exec.api_version
-              command: attributes.kubernetes_provider_exec.command
-              args: attributes.kubernetes_provider_exec.args
+              api_version: kubernetes_provider_exec.api_version
+              command: kubernetes_provider_exec.command
+              args: kubernetes_provider_exec.args
       kubernetes-alpha:
         source: hashicorp/kubernetes-alpha
         version: 0.6.0
         attributes:
-          host: attributes.cluster_endpoint
-          cluster_ca_certificate: attributes.cluster_ca_certificate
+          host: cluster_endpoint
+          cluster_ca_certificate: cluster_ca_certificate
           exec:
-            api_version: attributes.kubernetes_provider_exec.api_version
-            command: attributes.kubernetes_provider_exec.command
-            args: attributes.kubernetes_provider_exec.args
-  attributes:
-    type: '@facets/eks'
-    title: EKS Cluster Attributes
-    description: Additional EKS cluster attributes without provider configuration
+            api_version: kubernetes_provider_exec.api_version
+            command: kubernetes_provider_exec.command
+            args: kubernetes_provider_exec.args
 spec:
   type: object
   x-ui-order:

--- a/modules/kubernetes_cluster/eks_standard/1.0/outputs.tf
+++ b/modules/kubernetes_cluster/eks_standard/1.0/outputs.tf
@@ -16,6 +16,7 @@ locals {
     cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
     cluster_security_group_id         = module.eks.cluster_security_group_id
     cloud_provider                    = "AWS"
+    cluster_location                  = var.inputs.cloud_account.attributes.aws_region
     kubernetes_provider_exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "bash"

--- a/modules/kubernetes_cluster/gke/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/gke/1.0/facets.yaml
@@ -79,6 +79,10 @@ inputs:
     - google-beta
 outputs:
   default:
+    type: '@facets/gke'
+    title: GKE Cluster Attributes
+    description: Additional GKE cluster attributes without provider configuration
+  attributes:
     type: '@facets/kubernetes-details'
     title: Kubernetes Cluster Output
     providers:
@@ -86,37 +90,33 @@ outputs:
         source: hashicorp/kubernetes
         version: 2.38.0
         attributes:
-          host: attributes.cluster_endpoint
-          cluster_ca_certificate: attributes.cluster_ca_certificate
+          host: cluster_endpoint
+          cluster_ca_certificate: cluster_ca_certificate
           exec:
-            api_version: attributes.kubernetes_provider_exec.api_version
-            command: attributes.kubernetes_provider_exec.command
-            args: attributes.kubernetes_provider_exec.args
+            api_version: kubernetes_provider_exec.api_version
+            command: kubernetes_provider_exec.command
+            args: kubernetes_provider_exec.args
       helm:
         source: hashicorp/helm
         version: 2.17.0
         attributes:
           kubernetes:
-            host: attributes.cluster_endpoint
-            cluster_ca_certificate: attributes.cluster_ca_certificate
+            host: cluster_endpoint
+            cluster_ca_certificate: cluster_ca_certificate
             exec:
-              api_version: attributes.kubernetes_provider_exec.api_version
-              command: attributes.kubernetes_provider_exec.command
-              args: attributes.kubernetes_provider_exec.args
+              api_version: kubernetes_provider_exec.api_version
+              command: kubernetes_provider_exec.command
+              args: kubernetes_provider_exec.args
       kubernetes-alpha:
         source: hashicorp/kubernetes-alpha
         version: 0.6.0
         attributes:
-          host: attributes.cluster_endpoint
-          cluster_ca_certificate: attributes.cluster_ca_certificate
+          host: cluster_endpoint
+          cluster_ca_certificate: cluster_ca_certificate
           exec:
-            api_version: attributes.kubernetes_provider_exec.api_version
-            command: attributes.kubernetes_provider_exec.command
-            args: attributes.kubernetes_provider_exec.args
-  attributes:
-    type: '@facets/gke'
-    title: GKE Cluster Attributes
-    description: Additional GKE cluster attributes without provider configuration
+            api_version: kubernetes_provider_exec.api_version
+            command: kubernetes_provider_exec.command
+            args: kubernetes_provider_exec.args
 sample:
   kind: kubernetes_cluster
   flavor: gke

--- a/outputs/eks/outputs.yaml
+++ b/outputs/eks/outputs.yaml
@@ -13,11 +13,17 @@ properties:
           type: string
         cluster_endpoint:
           type: string
+        cluster_iam_role_arn:
+          type: string
         cluster_id:
           type: string
         cluster_name:
           type: string
         cluster_location:
+          type: string
+        cluster_primary_security_group_id:
+          type: string
+        cluster_security_group_id:
           type: string
         cluster_version:
           type: string

--- a/outputs/gke/outputs.yaml
+++ b/outputs/gke/outputs.yaml
@@ -66,6 +66,17 @@ properties:
               type: string
             host:
               type: string
+            kubernetes_provider_exec:
+              type: object
+              properties:
+                api_version:
+                  type: string
+                args:
+                  type: array
+                  items:
+                    type: string
+                command:
+                  type: string
             secrets:
               type: string
 providers: []


### PR DESCRIPTION
## Summary

- Standardize all `kubernetes_cluster` modules to follow a consistent output pattern:
  - `default` → cloud-specific type (`@facets/eks`, `@facets/gke`, `@facets/azure_aks`) — no providers
  - `attributes` → generic type (`@facets/kubernetes-details`) — with kubernetes/helm/kubernetes-alpha providers
- Fix output schema mismatches (missing fields in `@facets/eks` and `@facets/gke`)
- Add missing `cluster_location` to `eks_standard` output_attributes
- Codify the convention in CLAUDE.md

## Changes

| File | Change |
|------|--------|
| `eks_automode/1.0/facets.yaml` | Swap default/attributes outputs, fix provider attribute paths (remove `attributes.` prefix) |
| `gke/1.0/facets.yaml` | Swap default/attributes outputs, fix provider attribute paths |
| `aks/1.0/facets.yaml` | Swap default/attributes outputs, fix provider attribute paths |
| `eks_standard/1.0/outputs.tf` | Add missing `cluster_location` field |
| `outputs/eks/outputs.yaml` | Add `cluster_iam_role_arn`, `cluster_primary_security_group_id`, `cluster_security_group_id` |
| `outputs/gke/outputs.yaml` | Add `kubernetes_provider_exec` to `interfaces.kubernetes` |
| `CLAUDE.md` | Add provider-exposing module output convention |

## Consuming modules impact

- **24 cloud-agnostic modules** (`modules/common/*`, `modules/datastore/*`) consume `@facets/kubernetes-details` — unaffected
- **9 cloud-specific consumers** consume `@facets/eks`/`@facets/gke`/`@facets/azure_aks` — unaffected (providers resolve at module level)

## Test plan

- [ ] Verify eks_standard dry-run passes: `raptor create iac-module -f modules/kubernetes_cluster/eks_standard/1.0 --dry-run`
- [ ] Verify eks_automode dry-run passes: `raptor create iac-module -f modules/kubernetes_cluster/eks_automode/1.0 --dry-run`
- [ ] Verify gke dry-run passes: `raptor create iac-module -f modules/kubernetes_cluster/gke/1.0 --dry-run`
- [ ] Verify aks dry-run passes: `raptor create iac-module -f modules/kubernetes_cluster/aks/1.0 --dry-run`
- [ ] Deploy to a test environment and verify providers flow correctly to consuming modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)