### PR TITLE
Add output_name to blueprint inputs consuming kubernetes-details

### DIFF
--- a/project-type/aws/base/k8s_access_controls/instances/k8s-access-controls.json
+++ b/project-type/aws/base/k8s_access_controls/instances/k8s-access-controls.json
@@ -319,7 +319,8 @@
   "inputs": {
     "kubernetes_details": {
       "resource_type": "kubernetes_cluster",
-      "resource_name": "cluster"
+      "resource_name": "cluster",
+      "output_name": "attributes"
     }
   },
   "advanced": {

--- a/project-type/aws/base/k8s_callback/instances/k8s-callback.json
+++ b/project-type/aws/base/k8s_callback/instances/k8s-callback.json
@@ -7,7 +7,8 @@
   "inputs": {
     "kubernetes_details": {
       "resource_name": "cluster",
-      "resource_type": "kubernetes_cluster"
+      "resource_type": "kubernetes_cluster",
+      "output_name": "attributes"
     }
   }
 }

--- a/project-type/azure/base/k8s_access_controls/instances/k8s-access-controls.json
+++ b/project-type/azure/base/k8s_access_controls/instances/k8s-access-controls.json
@@ -319,7 +319,8 @@
   "inputs": {
     "kubernetes_details": {
       "resource_type": "kubernetes_cluster",
-      "resource_name": "cluster"
+      "resource_name": "cluster",
+      "output_name": "attributes"
     }
   },
   "advanced": {

--- a/project-type/azure/base/k8s_callback/instances/k8s-callback.json
+++ b/project-type/azure/base/k8s_callback/instances/k8s-callback.json
@@ -7,7 +7,8 @@
   "inputs": {
     "kubernetes_details": {
       "resource_name": "cluster",
-      "resource_type": "kubernetes_cluster"
+      "resource_type": "kubernetes_cluster",
+      "output_name": "attributes"
     }
   }
 }

--- a/project-type/gcp/base/k8s_access_controls/instances/k8s-access-controls.json
+++ b/project-type/gcp/base/k8s_access_controls/instances/k8s-access-controls.json
@@ -319,7 +319,8 @@
   "inputs": {
     "kubernetes_details": {
       "resource_type": "kubernetes_cluster",
-      "resource_name": "cluster"
+      "resource_name": "cluster",
+      "output_name": "attributes"
     }
   },
   "advanced": {

--- a/project-type/gcp/base/k8s_callback/instances/k8s-callback.json
+++ b/project-type/gcp/base/k8s_callback/instances/k8s-callback.json
@@ -7,7 +7,8 @@
   "inputs": {
     "kubernetes_details": {
       "resource_name": "cluster",
-      "resource_type": "kubernetes_cluster"
+      "resource_type": "kubernetes_cluster",
+      "output_name": "attributes"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Added `"output_name": "attributes"` to the `kubernetes_details` input in **6 blueprint JSONs** across all 3 cloud project types (AWS, GCP, Azure)
- **k8s_callback** (3 files) and **k8s_access_controls** (3 files) consume `@facets/kubernetes-details` which is exposed under the `attributes` output key, not `default`
- Without explicit `output_name`, the system defaults to `default` (which is `@facets/eks`, `@facets/gke`, `@facets/azure_aks`), causing type mismatches

## Test plan
- [x] `raptor create iac-module -f modules/common/k8s_callback/k8s_standard/1.0 --dry-run` passes
- [x] `raptor create iac-module -f modules/common/k8s_access_controls/k8s_standard/1.0 --dry-run` passes