### PR TITLE
fix: make k8s_git field descriptions provider-neutral

### DIFF
--- a/modules/common/helm/k8s_git/1.0/facets.yaml
+++ b/modules/common/helm/k8s_git/1.0/facets.yaml
@@ -1,0 +1,146 @@
+intent: helm
+flavor: k8s_git
+version: '1.0'
+description: Deploy a Helm chart from a private Git repository using sparse checkout
+intentDetails:
+  type: Kubernetes Resources
+  description: Deploy applications to Kubernetes using Helm charts from Git repositories
+  displayName: Helm
+  iconUrl: https://raw.githubusercontent.com/Facets-cloud/facets-modules-redesign/main/icons/helm.svg
+clouds:
+- aws
+- azure
+- gcp
+- kubernetes
+inputs:
+  kubernetes_details:
+    type: '@facets/kubernetes-details'
+    optional: false
+    displayName: Kubernetes Cluster
+    default:
+      resource_type: kubernetes_cluster
+      resource_name: default
+    providers:
+    - kubernetes
+    - helm
+    - kubernetes-alpha
+spec:
+  title: Helm Chart from Git Repository
+  description: Deploy a Helm chart from a private Git repository with authentication
+  type: object
+  properties:
+    release_name:
+      type: string
+      title: Release Name
+      description: Name override for the Helm release (by default uses the resource name)
+      x-ui-placeholder: "my-helm-release"
+      x-ui-error-message: "Must be a valid Kubernetes resource name"
+    git_base_url:
+      type: string
+      title: Git Base URL
+      description: "Base URL of the Git provider (e.g. github.com, gitlab.com, bitbucket.org)"
+      default: "github.com"
+      x-ui-placeholder: "github.com"
+    git_repository:
+      type: string
+      title: Git Repository Name
+      description: The Git repository name (without URL)
+      x-ui-placeholder: "my-repo"
+    git_owner:
+      type: string
+      title: Git Owner
+      description: Owner of the repository
+      x-ui-placeholder: "Enter repository owner or organization"
+    git_username:
+      type: string
+      title: Git Username
+      description: Username for Git authentication
+      x-ui-variable-ref: true
+      x-ui-placeholder: "Enter your Git username"
+    git_token:
+      type: string
+      title: Git Personal Access Token
+      description: Personal Access Token for Git authentication
+      x-ui-secret-ref: true
+    chart_path:
+      type: string
+      title: Chart Path
+      description: Path to the chart directory within the repository
+      default: ""
+      x-ui-placeholder: "charts/my-chart"
+    git_ref:
+      type: string
+      title: Git Reference
+      description: Git branch, tag, or commit to use
+      default: "main"
+    namespace:
+      type: string
+      title: Namespace
+      description: Kubernetes namespace to deploy the chart (uses environment namespace
+        if empty)
+      default: ""
+      x-ui-typeable: true
+      x-ui-api-source:
+        endpoint: "/cc-ui/v1/dropdown/stack/{{stackName}}/resources-info"
+        method: GET
+        params:
+          includeContent: false
+        labelKey: resourceName
+        valueKey: resourceName
+        valueTemplate: "${namespace.{{value}}.out.attributes.name}"
+        filterConditions:
+        - field: resourceType
+          value: namespace
+      x-ui-error-message: "Must be a valid Kubernetes namespace name or empty"
+    wait_config:
+      type: object
+      title: Wait Configuration
+      description: Configuration for waiting on deployment
+      x-ui-toggle: true
+      properties:
+        wait:
+          type: boolean
+          title: Wait for Deployment
+          description: Wait for the deployment to complete
+          default: true
+        timeout:
+          type: number
+          title: Timeout (seconds)
+          description: Time to wait for deployment completion
+          default: 300
+          minimum: 1
+          maximum: 3600
+      required:
+      - wait
+    values:
+      type: object
+      title: Helm Values
+      description: Values to pass to the Helm chart
+      x-ui-yaml-editor: true
+  required:
+  - git_repository
+  - git_owner
+  - git_username
+  - git_token
+outputs:
+  default:
+    type: '@facets/helm'
+    title: Helm Release
+sample:
+  kind: helm
+  flavor: k8s_git
+  disabled: true
+  version: '1.0'
+  spec:
+    git_base_url: "github.com"
+    git_repository: "my-charts"
+    git_owner: "myowner"
+    git_username: "myuser"
+    git_token: "token"
+    chart_path: "charts/app"
+    git_ref: "main"
+    namespace: ""
+    wait_config:
+      wait: true
+      timeout: 300
+    values: {}


### PR DESCRIPTION
## Summary
- Updated `git_base_url` description to mention GitHub, GitLab, and Bitbucket as example providers
- Changed `git_owner` placeholder from GitHub-specific wording to generic "Enter repository owner or organization"

## Test plan
- [x] `raptor create iac-module --dry-run` passes
- [ ] Publish module to CP and verify field descriptions in UI