### PR TITLE
fix intentDetails.type

### DIFF
--- a/rules.md
+++ b/rules.md
@@ -660,7 +660,7 @@ intentDetails:
 
 **Valid `intentDetails.type` values:**
 - `Cloud & Infrastructure`
-- `Managed Datastores`
+- `Datastores`
 - `Kubernetes`
 - `Monitoring & Observability`
 - `Operators`


### PR DESCRIPTION
### FIX - RULE-021

#### intentDetails.type 
- We are using `Datastores` as a intentType used across all datastore modules not `Managed Datastores`.

 
 ```bash
  Rule: RULE-021
  Status: FAIL
  Finding: intentDetails.type is Datastores — valid values are Cloud & Infrastructure, Managed Datastores, Kubernetes, Monitoring & Observability, Operators. Should be Managed Datastores 
  ```