### PR TITLE
added actions support for helm/k8s_standard

### DIFF
--- a/modules/common/helm/k8s_standard/1.0/actions.tf
+++ b/modules/common/helm/k8s_standard/1.0/actions.tf
@@ -1,0 +1,64 @@
+resource "facets_tekton_action_kubernetes" "helm_history" {
+  count                = local.enable_actions
+  name                 = "helm-history"
+  description          = "Retrieves helm release history for the deployed chart"
+  facets_resource_name = var.instance_name
+  facets_environment   = var.environment.unique_name
+  facets_resource      = var.instance
+
+  steps = [
+    {
+      name   = "get-helm-history"
+      image  = "alpine/helm:latest"
+      script = <<-EOT
+        #!/bin/bash
+        echo "Fetching helm history for helm release: ${helm_release.external_helm_charts.name}"
+        helm history ${helm_release.external_helm_charts.name} -n ${helm_release.external_helm_charts.namespace}
+      EOT
+    }
+  ]
+}
+
+resource "facets_tekton_action_kubernetes" "helm_rollback" {
+  count                = local.enable_actions
+  name                 = "helm-rollback"
+  description          = "Rolls back helm release to a specified revision"
+  facets_resource_name = var.instance_name
+  facets_environment   = var.environment.unique_name
+  facets_resource      = var.instance
+
+  params = [
+    {
+      name = "revision"
+      type = "string"
+    }
+  ]
+
+  steps = [
+    {
+      name   = "rollback-helm-release"
+      image  = "alpine/helm:latest"
+      script = <<-EOT
+        #!/bin/bash
+        REVISION="$(params.revision)"
+
+        if [ -z "$REVISION" ]; then
+          echo "error: Revision number is required"
+          exit 1
+        fi
+
+        echo "Rolling back release ${helm_release.external_helm_charts.name} to revision $REVISION"
+        helm rollback ${helm_release.external_helm_charts.name} $REVISION -n ${helm_release.external_helm_charts.namespace}
+
+        if [ $? -eq 0 ]; then
+          echo "Rollback successful"
+          echo "Current release status:"
+          helm status ${helm_release.external_helm_charts.name} -n ${helm_release.external_helm_charts.namespace}
+        else
+          echo "Rollback failed"
+          exit 1
+        fi
+      EOT
+    }
+  ]
+}

--- a/modules/common/helm/k8s_standard/1.0/facets.yaml
+++ b/modules/common/helm/k8s_standard/1.0/facets.yaml
@@ -103,6 +103,11 @@ spec:
       default: {}
       x-ui-yaml-editor: true
       x-ui-placeholder: Enter values in YAML format
+    enable_actions:
+      type: boolean
+      title: Enable Actions
+      description: Enable Tekton actions for helm history and rollback
+      default: false
   required:
   - helm
   - values
@@ -124,6 +129,7 @@ sample:
       namespace: default
       wait: false
     values: {}
+    enable_actions: false
 iac:
   validated_files:
   - variables.tf

--- a/modules/common/helm/k8s_standard/1.0/main.tf
+++ b/modules/common/helm/k8s_standard/1.0/main.tf
@@ -1,3 +1,7 @@
+locals {
+  enable_actions = lookup(var.instance.spec, "enable_actions", false) ? 1 : 0
+}
+
 resource "helm_release" "external_helm_charts" {
   chart               = var.instance.spec["helm"]["chart"]
   name                = var.instance_name

--- a/modules/common/helm/k8s_standard/1.0/variables.tf
+++ b/modules/common/helm/k8s_standard/1.0/variables.tf
@@ -12,7 +12,8 @@ variable "instance" {
         repository_username = optional(string)
         repository_password = optional(string)
       })
-      values = optional(any)
+      values         = optional(object({}))
+      enable_actions = optional(bool, false)
     })
   })
 


### PR DESCRIPTION
## PR description
This PR adds **Tekton actions** support to the `modules/common/helm/k8s_standard/1.0` module to support common Helm operational workflows.

### What changed
- Added a new Terraform file to define two Tekton actions (guarded by a toggle):
  - **`helm-history`**: runs `helm history <release> -n <namespace>`
  - **`helm-rollback`**: rolls back to a user-specified `revision` and prints status after rollback
- Introduced a module toggle **`enable_actions`** (default: `false`)
  - Added to `facets.yaml` schema + sample
  - Wired into Terraform via `local.enable_actions` and used as `count` for action resources
- Updated module variable typing to include:
  - `enable_actions = optional(bool, false)`
  - (and tightened `values` to `optional(object({}))`)

### Files changed
- `modules/common/helm/k8s_standard/1.0/actions.tf` (new): defines `facets_tekton_action_kubernetes` resources for history and rollback
- `modules/common/helm/k8s_standard/1.0/main.tf`: adds `locals { enable_actions = ... }`
- `modules/common/helm/k8s_standard/1.0/facets.yaml`: adds `spec.enable_actions` + sample value
- `modules/common/helm/k8s_standard/1.0/variables.tf`: adds `enable_actions` to spec and updates `values` type