### PR TITLE
added support to override the default helm values

### DIFF
--- a/modules/aws_alb_controller/standard/1.0/facets.yaml
+++ b/modules/aws_alb_controller/standard/1.0/facets.yaml
@@ -47,6 +47,15 @@ sample:
     controller_replicas: 1
     controller_version: "3.0.0"
   version: "1.0"
+metadata: 
+  type: object
+  title: Metadata object of the resource
+  description: Contains the metadata information of the resource such as name. 
+  properties:
+    name: 
+      type: string
+      title: Name of the resource.
+      description: Name of the resource if specified otherwise fallback will be module internal nameing.
 spec:
   description: Configure the AWS Load Balancer Controller for your EKS cluster
   properties:

--- a/modules/aws_alb_controller/standard/1.0/facets.yaml
+++ b/modules/aws_alb_controller/standard/1.0/facets.yaml
@@ -67,6 +67,16 @@ spec:
       title: Resource Tags
       type: object
       x-ui-yaml-editor: true
+    aws_alb_controller:
+      type: object
+      title: AWS ALB Controller Configuration
+      description: Additional AWS ALB controller configuration
+      properties:
+        values: 
+          type: object
+          title: Helm Values Override
+          description: Override default helm chart values. Any values provided here will take precedence over module defaults.
+          x-ui-yaml-editor: true
   required:
     - controller_version
   title: AWS ALB Controller Configuration

--- a/modules/aws_alb_controller/standard/1.0/facets.yaml
+++ b/modules/aws_alb_controller/standard/1.0/facets.yaml
@@ -47,15 +47,6 @@ sample:
     controller_replicas: 1
     controller_version: "3.0.0"
   version: "1.0"
-metadata: 
-  type: object
-  title: Metadata object of the resource
-  description: Contains the metadata information of the resource such as name. 
-  properties:
-    name: 
-      type: string
-      title: Name of the resource.
-      description: Name of the resource if specified otherwise fallback will be module internal nameing.
 spec:
   description: Configure the AWS Load Balancer Controller for your EKS cluster
   properties:

--- a/modules/aws_alb_controller/standard/1.0/main.tf
+++ b/modules/aws_alb_controller/standard/1.0/main.tf
@@ -8,7 +8,8 @@ module "name" {
 }
 
 locals {
-  name                       = module.name.name
+  metadata                   = lookup(var.instance, "metadata", {})
+  name                       = lookup(local.metadata, "name", module.name.name)
   controller_namespace       = "kube-system"
   controller_service_account = "aws-load-balancer-controller"
   cluster_name               = var.inputs.eks_details.attributes.cluster_name

--- a/modules/aws_alb_controller/standard/1.0/main.tf
+++ b/modules/aws_alb_controller/standard/1.0/main.tf
@@ -8,8 +8,7 @@ module "name" {
 }
 
 locals {
-  metadata                   = lookup(var.instance, "metadata", {})
-  name                       = lookup(local.metadata, "name", module.name.name)
+  name                       = lookup(local.spec, "name", module.name.name)
   controller_namespace       = "kube-system"
   controller_service_account = "aws-load-balancer-controller"
   cluster_name               = var.inputs.eks_details.attributes.cluster_name

--- a/modules/aws_alb_controller/standard/1.0/main.tf
+++ b/modules/aws_alb_controller/standard/1.0/main.tf
@@ -8,7 +8,7 @@ module "name" {
 }
 
 locals {
-  name                       = lookup(local.spec, "name", module.name.name)
+  name                       = module.name.name
   controller_namespace       = "kube-system"
   controller_service_account = "aws-load-balancer-controller"
   cluster_name               = var.inputs.eks_details.attributes.cluster_name

--- a/modules/aws_alb_controller/standard/1.0/main.tf
+++ b/modules/aws_alb_controller/standard/1.0/main.tf
@@ -16,7 +16,8 @@ locals {
   oidc_provider              = var.inputs.eks_details.attributes.oidc_provider
   vpc_id                     = var.inputs.network_details.attributes.vpc_id
   aws_region                 = var.inputs.cloud_account.attributes.aws_region
-
+  spec                       = lookup(var.instance, "spec", {})
+  additional_helm_values     = lookup(lookup(local.spec, "aws_alb_controller", {}), "values", {})
   instance_tags = merge(
     var.environment.cloud_tags,
     lookup(var.instance.spec, "tags", {}),
@@ -349,7 +350,8 @@ resource "helm_release" "alb_controller" {
           memory = "512Mi"
         }
       }
-    })
+    }),
+    yamlencode(local.additional_helm_values)
   ]
 
   depends_on = [


### PR DESCRIPTION
Previously it was not possible to provide helm values to the aws alb controller helm chart. 