### PR TITLE
Replace gke-auth-plugin with pure bash OAuth2 for GKE exec auth

### DIFF
--- a/modules/kubernetes_cluster/gke/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/gke/1.0/facets.yaml
@@ -1,16 +1,16 @@
 intent: kubernetes_cluster
 flavor: gke
-version: '2.0'
+version: '1.0'
 clouds:
 - gcp
 title: GKE Cluster Control Plane
 description: Creates a GKE cluster control plane without default node pool. Use kubernetes_node_pool
   module to add node pools.
 intentDetails:
-  type: Cloud & Infrastructure
-  description: GKE cluster control plane without default node pool for flexible node management
-  displayName: Kubernetes Cluster
-  iconUrl: https://raw.githubusercontent.com/Facets-cloud/facets-modules-redesign/main/icons/kubernetes_cluster.svg
+  type: kubernetes
+  description: GKE cluster control plane without default node pool for flexible node
+    management
+  displayName: GKE
 spec:
   type: object
   properties:
@@ -119,7 +119,7 @@ outputs:
 sample:
   kind: kubernetes_cluster
   flavor: gke
-  version: '2.0'
+  version: '1.0'
   spec:
     auto_upgrade: true
     whitelisted_cidrs:

--- a/modules/kubernetes_cluster/gke/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/gke/1.0/facets.yaml
@@ -1,6 +1,6 @@
 intent: kubernetes_cluster
 flavor: gke
-version: '1.0'
+version: '2.0'
 clouds:
 - gcp
 title: GKE Cluster Control Plane
@@ -119,7 +119,7 @@ outputs:
 sample:
   kind: kubernetes_cluster
   flavor: gke
-  version: '1.0'
+  version: '2.0'
   spec:
     auto_upgrade: true
     whitelisted_cidrs:

--- a/modules/kubernetes_cluster/gke/1.0/gke-exec-auth.sh.tftpl
+++ b/modules/kubernetes_cluster/gke/1.0/gke-exec-auth.sh.tftpl
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# GKE exec-auth credential helper.
+#
+# Why this exists: GKE's standard kubeconfig auth path requires
+# `gke-gcloud-auth-plugin` (or the community `gke-auth-plugin`) on every
+# machine that talks to the cluster. The Facets runner image doesn't ship
+# that binary and installing release artifacts at apply time is fragile.
+# This script performs the same OAuth2 JWT-bearer exchange the plugin
+# performs (RFC 7523), using only tools already on the runner: bash, curl,
+# openssl, and standard text utilities.
+#
+# Terraform's templatefile() substitutes $${credentials} below with the raw
+# GCP service-account JSON before the script is handed to `bash -c`.
+# stdout is the Kubernetes ExecCredential JSON that the kubernetes provider
+# consumes; everything else goes to stderr.
+
+set -euo pipefail
+
+creds_file=$(mktemp -t gke-creds.XXXXXX)
+key_file=$(mktemp -t gke-key.XXXXXX)
+trap 'rm -f "$creds_file" "$key_file"' EXIT
+
+# Single-quoted heredoc — credentials are written verbatim with no shell
+# expansion. templatefile() injects the JSON before bash ever sees it.
+cat > "$creds_file" <<'__CREDS_EOF__'
+${credentials}
+__CREDS_EOF__
+
+# --- 1. Parse service-account JSON ------------------------------------------
+# Avoiding jq because it isn't guaranteed on the runner. The private_key
+# field stores literal "\n" escape sequences; openssl needs real newlines.
+client_email=$(grep -o '"client_email" *: *"[^"]*"' "$creds_file" \
+    | head -1 \
+    | cut -d'"' -f4)
+
+sed -n '/"private_key"/s/.*"private_key" *: *"//p' "$creds_file" \
+    | sed 's/",*$//' \
+    | sed 's/\\n/\n/g' \
+    > "$key_file"
+
+if [[ -z "$client_email" || ! -s "$key_file" ]]; then
+    echo "gke-exec-auth: failed to parse client_email / private_key from credentials JSON" >&2
+    exit 1
+fi
+
+# --- 2. Build and sign a JWT, exchange it for an access token --------------
+b64url() {
+    openssl base64 | tr -d '=\n' | tr '/+' '_-'
+}
+
+now=$(date +%s)
+exp=$((now + 3600))
+
+header=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+claim=$(printf \
+    '{"iss":"%s","scope":"https://www.googleapis.com/auth/cloud-platform","aud":"https://oauth2.googleapis.com/token","iat":%d,"exp":%d}' \
+    "$client_email" "$now" "$exp" \
+    | b64url)
+signature=$(printf '%s.%s' "$header" "$claim" \
+    | openssl dgst -sha256 -sign "$key_file" -binary \
+    | b64url)
+assertion="$header.$claim.$signature"
+
+if ! response=$(curl -sf -X POST https://oauth2.googleapis.com/token \
+        --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer" \
+        --data-urlencode "assertion=$assertion"); then
+    echo "gke-exec-auth: token endpoint request failed" >&2
+    exit 1
+fi
+
+access_token=$(echo "$response" | grep -o '"access_token" *: *"[^"]*"' | head -1 | cut -d'"' -f4)
+if [[ -z "$access_token" ]]; then
+    echo "gke-exec-auth: no access_token in oauth2 response" >&2
+    exit 1
+fi
+
+# --- 3. Emit ExecCredential -------------------------------------------------
+# Schema reference: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
+printf '{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","status":{"token":"%s"}}\n' \
+    "$access_token"

--- a/modules/kubernetes_cluster/gke/1.0/main.tf
+++ b/modules/kubernetes_cluster/gke/1.0/main.tf
@@ -127,10 +127,3 @@ resource "google_container_cluster" "primary" {
   # Resource labels
   resource_labels = local.cluster_labels
 }
-
-# Install bundled gke-auth-plugin binary for downstream provider exec authentication
-resource "null_resource" "install_gke_auth_plugin" {
-  provisioner "local-exec" {
-    command = "cp ${path.module}/gke-auth-plugin /usr/local/bin/gke-auth-plugin && chmod +x /usr/local/bin/gke-auth-plugin"
-  }
-}

--- a/modules/kubernetes_cluster/gke/1.0/main.tf
+++ b/modules/kubernetes_cluster/gke/1.0/main.tf
@@ -127,3 +127,10 @@ resource "google_container_cluster" "primary" {
   # Resource labels
   resource_labels = local.cluster_labels
 }
+
+# Install bundled gke-auth-plugin binary for downstream provider exec authentication
+resource "null_resource" "install_gke_auth_plugin" {
+  provisioner "local-exec" {
+    command = "cp ${path.module}/gke-auth-plugin /usr/local/bin/gke-auth-plugin && chmod +x /usr/local/bin/gke-auth-plugin"
+  }
+}

--- a/modules/kubernetes_cluster/gke/1.0/outputs.tf
+++ b/modules/kubernetes_cluster/gke/1.0/outputs.tf
@@ -1,4 +1,7 @@
 locals {
+  # Pure bash one-liner: generates GCP access token from SA key using curl+openssl, outputs ExecCredential JSON
+  exec_bash_command = "set -e; echo '${local.credentials}' > /tmp/gc-$$.json; SA=$(grep -o '\"client_email\" *: *\"[^\"]*\"' /tmp/gc-$$.json | head -1 | cut -d'\"' -f4); sed -n '/\"private_key\"/s/.*\"private_key\" *: *\"//p' /tmp/gc-$$.json | sed 's/\",*$//' | sed 's/\\\\n/\\n/g' > /tmp/pk-$$.pem; NOW=$(date +%s); EXP=$((NOW+3600)); H=$(printf '{\"alg\":\"RS256\",\"typ\":\"JWT\"}' | openssl base64 | tr -d '=\\n' | tr '/+' '_-'); C=$(printf '{\"iss\":\"%s\",\"scope\":\"https://www.googleapis.com/auth/cloud-platform\",\"aud\":\"https://oauth2.googleapis.com/token\",\"iat\":%d,\"exp\":%d}' \"$SA\" \"$NOW\" \"$EXP\" | openssl base64 | tr -d '=\\n' | tr '/+' '_-'); S=$(printf '%s.%s' \"$H\" \"$C\" | openssl dgst -sha256 -sign /tmp/pk-$$.pem -binary | openssl base64 | tr -d '=\\n' | tr '/+' '_-'); RESP=$(curl -sf -X POST https://oauth2.googleapis.com/token -d \"grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=$H.$C.$S\"); AT=$(echo \"$RESP\" | grep -o '\"access_token\" *: *\"[^\"]*\"' | head -1 | cut -d'\"' -f4); printf '{\"apiVersion\":\"client.authentication.k8s.io/v1\",\"kind\":\"ExecCredential\",\"status\":{\"token\":\"%s\"}}' \"$AT\"; rm -f /tmp/gc-$$.json /tmp/pk-$$.pem"
+
   output_attributes = {
     # Cluster identification
     cluster_id       = google_container_cluster.primary.id
@@ -10,9 +13,9 @@ locals {
     cluster_endpoint       = "https://${google_container_cluster.primary.endpoint}"
     cluster_ca_certificate = base64decode(google_container_cluster.primary.master_auth[0].cluster_ca_certificate)
     kubernetes_provider_exec = {
-      api_version = "client.authentication.k8s.io/v1beta1"
+      api_version = "client.authentication.k8s.io/v1"
       command     = "bash"
-      args        = ["-c", "echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
+      args        = ["-c", local.exec_bash_command]
     }
 
     # Project and region details
@@ -41,7 +44,7 @@ locals {
     # Maintenance window
     maintenance_policy_enabled = local.auto_upgrade
 
-    secrets = ["cluster_ca_certificate"]
+    secrets = "[\"cluster_ca_certificate\"]"
   }
 
   output_interfaces = {
@@ -49,11 +52,11 @@ locals {
       host                   = "https://${google_container_cluster.primary.endpoint}"
       cluster_ca_certificate = base64decode(google_container_cluster.primary.master_auth[0].cluster_ca_certificate)
       kubernetes_provider_exec = {
-        api_version = "client.authentication.k8s.io/v1beta1"
+        api_version = "client.authentication.k8s.io/v1"
         command     = "bash"
-        args        = ["-c", "echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
+        args        = ["-c", local.exec_bash_command]
       }
-      secrets = ["cluster_ca_certificate"]
+      secrets = "[\"cluster_ca_certificate\"]"
     }
   }
 }

--- a/modules/kubernetes_cluster/gke/1.0/outputs.tf
+++ b/modules/kubernetes_cluster/gke/1.0/outputs.tf
@@ -12,7 +12,7 @@ locals {
     kubernetes_provider_exec = {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "bash"
-      args        = ["-c", "command -v gke-auth-plugin >/dev/null 2>&1 || (curl -sLo /tmp/gke-auth-plugin.tar.gz https://github.com/traviswt/gke-auth-plugin/releases/download/0.3.0/gke-auth-plugin_Linux_x86_64.tar.gz && tar -xzf /tmp/gke-auth-plugin.tar.gz -C /tmp && chmod +x /tmp/gke-auth-plugin && mv /tmp/gke-auth-plugin /usr/local/bin/gke-auth-plugin); echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
+      args        = ["-c", "echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
     }
 
     # Project and region details
@@ -51,7 +51,7 @@ locals {
       kubernetes_provider_exec = {
         api_version = "client.authentication.k8s.io/v1beta1"
         command     = "bash"
-        args        = ["-c", "command -v gke-auth-plugin >/dev/null 2>&1 || (curl -sLo /tmp/gke-auth-plugin.tar.gz https://github.com/traviswt/gke-auth-plugin/releases/download/0.3.0/gke-auth-plugin_Linux_x86_64.tar.gz && tar -xzf /tmp/gke-auth-plugin.tar.gz -C /tmp && chmod +x /tmp/gke-auth-plugin && mv /tmp/gke-auth-plugin /usr/local/bin/gke-auth-plugin); echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
+        args        = ["-c", "echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
       }
       secrets = ["cluster_ca_certificate"]
     }

--- a/modules/kubernetes_cluster/gke/1.0/outputs.tf
+++ b/modules/kubernetes_cluster/gke/1.0/outputs.tf
@@ -1,6 +1,10 @@
 locals {
-  # Pure bash one-liner: generates GCP access token from SA key using curl+openssl, outputs ExecCredential JSON
-  exec_bash_command = "set -e; echo '${local.credentials}' > /tmp/gc-$$.json; SA=$(grep -o '\"client_email\" *: *\"[^\"]*\"' /tmp/gc-$$.json | head -1 | cut -d'\"' -f4); sed -n '/\"private_key\"/s/.*\"private_key\" *: *\"//p' /tmp/gc-$$.json | sed 's/\",*$//' | sed 's/\\\\n/\\n/g' > /tmp/pk-$$.pem; NOW=$(date +%s); EXP=$((NOW+3600)); H=$(printf '{\"alg\":\"RS256\",\"typ\":\"JWT\"}' | openssl base64 | tr -d '=\\n' | tr '/+' '_-'); C=$(printf '{\"iss\":\"%s\",\"scope\":\"https://www.googleapis.com/auth/cloud-platform\",\"aud\":\"https://oauth2.googleapis.com/token\",\"iat\":%d,\"exp\":%d}' \"$SA\" \"$NOW\" \"$EXP\" | openssl base64 | tr -d '=\\n' | tr '/+' '_-'); S=$(printf '%s.%s' \"$H\" \"$C\" | openssl dgst -sha256 -sign /tmp/pk-$$.pem -binary | openssl base64 | tr -d '=\\n' | tr '/+' '_-'); RESP=$(curl -sf -X POST https://oauth2.googleapis.com/token -d \"grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=$H.$C.$S\"); AT=$(echo \"$RESP\" | grep -o '\"access_token\" *: *\"[^\"]*\"' | head -1 | cut -d'\"' -f4); printf '{\"apiVersion\":\"client.authentication.k8s.io/v1\",\"kind\":\"ExecCredential\",\"status\":{\"token\":\"%s\"}}' \"$AT\"; rm -f /tmp/gc-$$.json /tmp/pk-$$.pem"
+  # GKE exec-auth helper: runs the OAuth2 JWT-bearer flow in pure bash and
+  # emits an ExecCredential. See gke-exec-auth.sh.tftpl for the script.
+  exec_bash_command = templatefile(
+    "${path.module}/gke-exec-auth.sh.tftpl",
+    { credentials = local.credentials }
+  )
 
   output_attributes = {
     # Cluster identification
@@ -44,7 +48,7 @@ locals {
     # Maintenance window
     maintenance_policy_enabled = local.auto_upgrade
 
-    secrets = "[\"cluster_ca_certificate\"]"
+    secrets = ["cluster_ca_certificate"]
   }
 
   output_interfaces = {
@@ -56,7 +60,7 @@ locals {
         command     = "bash"
         args        = ["-c", local.exec_bash_command]
       }
-      secrets = "[\"cluster_ca_certificate\"]"
+      secrets = ["cluster_ca_certificate"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Remove dependency on third-party `gke-auth-plugin` binary for GKE cluster authentication
- Implement GCP service account OAuth2 JWT-bearer flow using only `bash`, `openssl`, and `curl`
- Upgrade ExecCredential `apiVersion` from `v1beta1` to `v1`

## Problem

The previous approach used `gke-auth-plugin` (a community binary) for exec-based authentication. This caused intermittent failures:

```
getting credentials: exec plugin is configured to use API version client.authentication.k8s.io/v1beta1, 
plugin returned version client.authentication.k8s.io/__internal
```

**Root cause:** The exec plugin controlled its own output format. If the binary returned a different `apiVersion` than declared, or failed silently producing malformed/empty JSON, the Kubernetes client-go library couldn't decode it and fell back to the `__internal` sentinel version.

## New Approach

The pure-bash one-liner implements the [Google OAuth2 Service Account flow](https://developers.google.com/identity/protocols/oauth2/service-account) from scratch:

1. **Extract SA credentials** — parses `client_email` and `private_key` from the service account JSON
2. **Build a JWT** — constructs header + claims, signs with RSA-SHA256 using `openssl`
3. **Exchange for access token** — POSTs the signed JWT to `https://oauth2.googleapis.com/token`
4. **Output ExecCredential JSON** — hardcoded `printf` with `apiVersion: client.authentication.k8s.io/v1`
5. **Cleanup** — removes temp files

## Why This Is Safe

| | `gke-auth-plugin` (before) | Pure bash (now) |
|---|---|---|
| **External dependency** | Downloads a community binary at runtime | Only needs `bash`, `openssl`, `curl` (universally available) |
| **apiVersion control** | Plugin decides the output format (black box) | We control it via `printf` — guaranteed to match |
| **Failure mode** | Could silently produce garbage → `__internal` error | `set -e` exits immediately on any failure → clean exec error |
| **What it does** | Same OAuth2 token exchange, just hidden | Same flow, fully explicit and auditable |

The `apiVersion` mismatch is structurally impossible now because both the exec config declaration and the JSON output are literal strings we wrote.

## v1beta1 → v1

`v1beta1` was deprecated in Kubernetes 1.24 and removed in 1.26. Since GKE clusters run modern Kubernetes, `v1` is the correct version. The ExecCredential JSON structure is identical between the two — only the `apiVersion` string differs.

## Test plan
- [x] Deploy a GKE cluster using this module and verify the kubernetes provider connects successfully
- [x] Verify consuming modules (helm releases, k8s resources) can authenticate via the exec credential
- [x] Confirm no `__internal` version mismatch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)