### PR TITLE
feat: Add empty project type

### DIFF
--- a/project-type/empty/base/stack.json
+++ b/project-type/empty/base/stack.json
@@ -1,0 +1,3 @@
+{
+  "clusterVariablesMeta": {}
+}

--- a/project-type/empty/project-type.yml
+++ b/project-type/empty/project-type.yml
@@ -1,0 +1,13 @@
+name: empty
+description: Empty project type — a blank slate for building custom module sets from scratch.
+
+# Git repository details
+gitUrl: https://github.com/Facets-cloud/facets-modules-redesign.git
+gitRef: main
+baseTemplatePath: project-type/empty/base
+
+iacTool: TERRAFORM
+iacToolVersion: "1.5.7"
+
+# No modules — add your own via raptor create resource-type-mapping
+modules: []


### PR DESCRIPTION
## Summary
- Adds `project-type/empty/` with a minimal `project-type.yml` (no modules) and bare `base/stack.json`
- Provides a blank slate for users building custom module sets from scratch
- Used by `raptor import project-type -f ./project-type/empty/project-type.yml`

## Test plan
- [ ] Verify `raptor import project-type -f ./project-type/empty/project-type.yml` succeeds
- [ ] Verify imported project type has no modules and accepts new mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)