### PR TITLE
fix: k8s_callback input structure to match kubernetes-details output schema

### DIFF
--- a/modules/common/k8s_callback/k8s_standard/1.0/facets.yaml
+++ b/modules/common/k8s_callback/k8s_standard/1.0/facets.yaml
@@ -1,6 +1,6 @@
 intent: k8s_callback
 flavor: k8s_standard
-version: '1.1'
+version: '1.2'
 description: Creates ServiceAccount with admin role and registers OVH K8s credentials
   with Facets control plane
 intentDetails:
@@ -29,7 +29,7 @@ spec:
 sample:
   kind: k8s_callback
   flavor: k8s_standard
-  version: '1.1'
+  version: '1.2'
   disabled: false
   spec: {}
 iac:

--- a/modules/common/k8s_callback/k8s_standard/1.0/main.tf
+++ b/modules/common/k8s_callback/k8s_standard/1.0/main.tf
@@ -59,7 +59,7 @@ data "kubernetes_secret" "facets_admin_token" {
 # Make callback to control plane
 resource "null_resource" "add_k8s_creds_backend" {
   triggers = {
-    host       = var.inputs.kubernetes_details.cluster_endpoint
+    host       = var.inputs.kubernetes_details.attributes.cluster_endpoint
     token      = data.kubernetes_secret.facets_admin_token.data["token"]
     cluster_id = var.environment.environment_id
   }
@@ -71,7 +71,7 @@ resource "null_resource" "add_k8s_creds_backend" {
 curl -X POST "https://$TF_VAR_cc_host/cc/v1/clusters/${var.environment.environment_id}/credentials" \
   -H "accept: */*" \
   -H "Content-Type: application/json" \
-  -d "{\"kubernetesApiEndpoint\": \"${var.inputs.kubernetes_details.cluster_endpoint}\", \"kubernetesToken\": \"${data.kubernetes_secret.facets_admin_token.data["token"]}\"}" \
+  -d "{\"kubernetesApiEndpoint\": \"${var.inputs.kubernetes_details.attributes.cluster_endpoint}\", \"kubernetesToken\": \"${data.kubernetes_secret.facets_admin_token.data["token"]}\"}" \
   -H "X-DEPLOYER-INTERNAL-AUTH-TOKEN: $TF_VAR_cc_auth_token"
 EOF
   }

--- a/modules/common/k8s_callback/k8s_standard/1.0/variables.tf
+++ b/modules/common/k8s_callback/k8s_standard/1.0/variables.tf
@@ -28,11 +28,13 @@ variable "inputs" {
   description = "A map of inputs requested by the module developer."
   type = object({
     kubernetes_details = object({
-      cluster_endpoint       = optional(string)
-      cluster_ca_certificate = optional(string)
-      cluster_name           = optional(string)
-      cluster_version        = optional(string)
-      cluster_id             = optional(string)
+      attributes = object({
+        cluster_endpoint       = optional(string)
+        cluster_ca_certificate = optional(string)
+        cluster_name           = optional(string)
+        cluster_version        = optional(string)
+        cluster_id             = optional(string)
+      })
     })
   })
 }

--- a/project-type/aws/base/k8s_callback/instances/k8s-callback.json
+++ b/project-type/aws/base/k8s_callback/instances/k8s-callback.json
@@ -7,8 +7,7 @@
   "inputs": {
     "kubernetes_details": {
       "resource_name": "cluster",
-      "resource_type": "kubernetes_cluster",
-      "output_name": "attributes"
+      "resource_type": "kubernetes_cluster"
     }
   }
 }

--- a/project-type/azure/base/k8s_callback/instances/k8s-callback.json
+++ b/project-type/azure/base/k8s_callback/instances/k8s-callback.json
@@ -7,8 +7,7 @@
   "inputs": {
     "kubernetes_details": {
       "resource_name": "cluster",
-      "resource_type": "kubernetes_cluster",
-      "output_name": "attributes"
+      "resource_type": "kubernetes_cluster"
     }
   }
 }

--- a/project-type/gcp/base/k8s_callback/instances/k8s-callback.json
+++ b/project-type/gcp/base/k8s_callback/instances/k8s-callback.json
@@ -7,8 +7,7 @@
   "inputs": {
     "kubernetes_details": {
       "resource_name": "cluster",
-      "resource_type": "kubernetes_cluster",
-      "output_name": "attributes"
+      "resource_type": "kubernetes_cluster"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Updated `k8s_callback` module's `variables.tf` to nest input fields under `attributes` to match the `@facets/kubernetes-details` output type schema
- Updated `main.tf` references from `var.inputs.kubernetes_details.cluster_endpoint` to `var.inputs.kubernetes_details.attributes.cluster_endpoint`
- Removed `output_name: attributes` workaround from all three project-type configs (AWS, Azure, GCP)

## Test plan
- [ ] Deploy k8s_callback module against an EKS cluster and verify it resolves `cluster_endpoint` without needing `output_name: attributes`
- [ ] Verify the callback to control plane succeeds with correct endpoint
- [ ] Test against GCP and Azure clusters as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)