### PR TITLE
feat: Cluster-wide LimitRange module for ephemeral-storage defaults

### DIFF
--- a/modules/common/limit_range/default/1.0/facets.yaml
+++ b/modules/common/limit_range/default/1.0/facets.yaml
@@ -1,0 +1,221 @@
+intent: limit_range
+flavor: default
+version: '1.0'
+description: |
+  Applies Kubernetes LimitRange resources cluster-wide or to specific namespaces.
+  Containers without explicit resource requests/limits get these defaults injected
+  automatically. Supports per-namespace overrides and namespace exclusion.
+intentDetails:
+  type: Kubernetes Resources
+  description: Cluster-wide or namespace-scoped LimitRange for resource defaults
+  displayName: LimitRange
+  iconUrl: https://raw.githubusercontent.com/Facets-cloud/facets-modules-redesign/main/icons/k8s_resource.svg
+clouds:
+- aws
+- azure
+- gcp
+- kubernetes
+inputs:
+  kubernetes_details:
+    optional: false
+    type: '@facets/kubernetes-details'
+    displayName: Kubernetes Cluster
+    default:
+      resource_type: kubernetes_cluster
+      resource_name: default
+    providers:
+    - kubernetes
+spec:
+  title: LimitRange Configuration
+  description: Configure LimitRange defaults for resource requests and limits across cluster namespaces.
+  type: object
+  properties:
+    cluster_wide:
+      type: boolean
+      title: Cluster Wide
+      description: "When true, applies LimitRange to all namespaces (except excluded). When false, applies only to namespaces listed in target_namespaces."
+      default: true
+    exclude_namespaces:
+      type: array
+      title: Exclude Namespaces
+      description: Namespaces to skip when cluster_wide is true.
+      items:
+        type: string
+      default:
+      - kube-node-lease
+      - kube-public
+      x-ui-visible-if:
+        field: spec.cluster_wide
+        values:
+        - true
+    target_namespaces:
+      type: array
+      title: Target Namespaces
+      description: Namespaces to apply LimitRange to. Only used when cluster_wide is false.
+      items:
+        type: string
+      default: []
+      x-ui-visible-if:
+        field: spec.cluster_wide
+        values:
+        - false
+    limits:
+      type: object
+      title: Default Limits
+      description: Base LimitRange spec applied to all targeted namespaces.
+      properties:
+        type:
+          type: string
+          title: Limit Type
+          description: Kubernetes resource type this limit applies to.
+          enum:
+          - Container
+          - Pod
+          - PersistentVolumeClaim
+          default: Container
+        default:
+          type: object
+          title: Default Limits
+          description: Default resource limits injected into containers that don't set their own.
+          properties:
+            cpu:
+              type: string
+              title: CPU
+            memory:
+              type: string
+              title: Memory
+            ephemeral-storage:
+              type: string
+              title: Ephemeral Storage
+        default_request:
+          type: object
+          title: Default Requests
+          description: Default resource requests injected into containers that don't set their own.
+          properties:
+            cpu:
+              type: string
+              title: CPU
+            memory:
+              type: string
+              title: Memory
+            ephemeral-storage:
+              type: string
+              title: Ephemeral Storage
+        min:
+          type: object
+          title: Minimum Allowed
+          description: Hard floor. Pods requesting less than this are rejected at admission.
+          properties:
+            cpu:
+              type: string
+              title: CPU
+            memory:
+              type: string
+              title: Memory
+            ephemeral-storage:
+              type: string
+              title: Ephemeral Storage
+        max:
+          type: object
+          title: Maximum Allowed
+          description: Hard ceiling. Pods requesting more than this are rejected at admission.
+          properties:
+            cpu:
+              type: string
+              title: CPU
+            memory:
+              type: string
+              title: Memory
+            ephemeral-storage:
+              type: string
+              title: Ephemeral Storage
+        max_limit_request_ratio:
+          type: object
+          title: Max Limit/Request Ratio
+          description: Maximum allowed ratio between limit and request. Pods exceeding this ratio are rejected.
+          properties:
+            cpu:
+              type: string
+              title: CPU
+            memory:
+              type: string
+              title: Memory
+    namespace_overrides:
+      type: object
+      title: Namespace Overrides
+      description: Per-namespace overrides merged on top of the base limits. Keys are namespace names.
+      patternProperties:
+        "^[a-zA-Z0-9_-]+$":
+          type: object
+          properties:
+            default:
+              type: object
+              properties:
+                cpu:
+                  type: string
+                memory:
+                  type: string
+                ephemeral-storage:
+                  type: string
+            default_request:
+              type: object
+              properties:
+                cpu:
+                  type: string
+                memory:
+                  type: string
+                ephemeral-storage:
+                  type: string
+            min:
+              type: object
+              properties:
+                cpu:
+                  type: string
+                memory:
+                  type: string
+                ephemeral-storage:
+                  type: string
+            max:
+              type: object
+              properties:
+                cpu:
+                  type: string
+                memory:
+                  type: string
+                ephemeral-storage:
+                  type: string
+            max_limit_request_ratio:
+              type: object
+              properties:
+                cpu:
+                  type: string
+                memory:
+                  type: string
+      default: {}
+sample:
+  kind: limit_range
+  flavor: default
+  version: '1.0'
+  disabled: true
+  spec:
+    cluster_wide: true
+    exclude_namespaces:
+    - kube-node-lease
+    - kube-public
+    limits:
+      type: Container
+      default_request:
+        ephemeral-storage: "512Mi"
+      default:
+        ephemeral-storage: "5Gi"
+    namespace_overrides:
+      default:
+        default_request:
+          ephemeral-storage: "1Gi"
+        default:
+          ephemeral-storage: "10Gi"
+      tekton-pipelines:
+        default_request:
+          ephemeral-storage: "256Mi"
+        default:
+          ephemeral-storage: "2Gi"

--- a/modules/common/limit_range/default/1.0/main.tf
+++ b/modules/common/limit_range/default/1.0/main.tf
@@ -1,0 +1,60 @@
+locals {
+  spec = lookup(var.instance, "spec", {})
+
+  cluster_wide       = lookup(local.spec, "cluster_wide", true)
+  exclude_namespaces = toset(lookup(local.spec, "exclude_namespaces", ["kube-node-lease", "kube-public"]))
+  target_namespaces  = toset(lookup(local.spec, "target_namespaces", []))
+
+  limits              = lookup(local.spec, "limits", {})
+  limit_type          = lookup(local.limits, "type", "Container")
+  base_default        = lookup(local.limits, "default", {})
+  base_default_req    = lookup(local.limits, "default_request", {})
+  base_min            = lookup(local.limits, "min", {})
+  base_max            = lookup(local.limits, "max", {})
+  base_ratio          = lookup(local.limits, "max_limit_request_ratio", {})
+  namespace_overrides = lookup(local.spec, "namespace_overrides", {})
+
+  # Resolve target namespace set based on mode
+  all_namespaces      = local.cluster_wide ? toset(data.kubernetes_all_namespaces.all[0].namespaces) : toset([])
+  filtered_all        = setsubtract(local.all_namespaces, local.exclude_namespaces)
+  resolved_namespaces = local.cluster_wide ? local.filtered_all : local.target_namespaces
+
+  # Build per-namespace limit specs with overrides merged on top of base
+  namespace_limits = {
+    for ns in local.resolved_namespaces : ns => {
+      default                 = length(lookup(lookup(local.namespace_overrides, ns, {}), "default", {})) > 0 ? merge(local.base_default, lookup(local.namespace_overrides[ns], "default", {})) : local.base_default
+      default_request         = length(lookup(lookup(local.namespace_overrides, ns, {}), "default_request", {})) > 0 ? merge(local.base_default_req, lookup(local.namespace_overrides[ns], "default_request", {})) : local.base_default_req
+      min                     = length(lookup(lookup(local.namespace_overrides, ns, {}), "min", {})) > 0 ? merge(local.base_min, lookup(local.namespace_overrides[ns], "min", {})) : local.base_min
+      max                     = length(lookup(lookup(local.namespace_overrides, ns, {}), "max", {})) > 0 ? merge(local.base_max, lookup(local.namespace_overrides[ns], "max", {})) : local.base_max
+      max_limit_request_ratio = length(lookup(lookup(local.namespace_overrides, ns, {}), "max_limit_request_ratio", {})) > 0 ? merge(local.base_ratio, lookup(local.namespace_overrides[ns], "max_limit_request_ratio", {})) : local.base_ratio
+    }
+  }
+}
+
+data "kubernetes_all_namespaces" "all" {
+  count = local.cluster_wide ? 1 : 0
+}
+
+resource "kubernetes_limit_range_v1" "this" {
+  for_each = local.namespace_limits
+
+  metadata {
+    name      = var.instance_name
+    namespace = each.key
+    labels = {
+      "app.kubernetes.io/managed-by" = "facets"
+      "facets.cloud/module"          = "limit-range"
+    }
+  }
+
+  spec {
+    limit {
+      type                    = local.limit_type
+      default                 = length(each.value.default) > 0 ? each.value.default : null
+      default_request         = length(each.value.default_request) > 0 ? each.value.default_request : null
+      min                     = length(each.value.min) > 0 ? each.value.min : null
+      max                     = length(each.value.max) > 0 ? each.value.max : null
+      max_limit_request_ratio = length(each.value.max_limit_request_ratio) > 0 ? each.value.max_limit_request_ratio : null
+    }
+  }
+}

--- a/modules/common/limit_range/default/1.0/outputs.tf
+++ b/modules/common/limit_range/default/1.0/outputs.tf
@@ -1,0 +1,9 @@
+locals {
+  output_attributes = {
+    namespaces_applied = keys(local.namespace_limits)
+    mode               = local.cluster_wide ? "cluster_wide" : "specific_namespaces"
+    limit_type         = local.limit_type
+  }
+
+  output_interfaces = {}
+}

--- a/modules/common/limit_range/default/1.0/variables.tf
+++ b/modules/common/limit_range/default/1.0/variables.tf
@@ -1,0 +1,70 @@
+variable "instance" {
+  description = "LimitRange instance configuration"
+  type = object({
+    kind    = optional(string)
+    flavor  = optional(string)
+    version = optional(string)
+    spec = optional(object({
+      cluster_wide       = optional(bool, true)
+      exclude_namespaces = optional(list(string), ["kube-node-lease", "kube-public"])
+      target_namespaces  = optional(list(string), [])
+      limits = optional(object({
+        type                    = optional(string, "Container")
+        default                 = optional(map(string), {})
+        default_request         = optional(map(string), {})
+        min                     = optional(map(string), {})
+        max                     = optional(map(string), {})
+        max_limit_request_ratio = optional(map(string), {})
+      }), {})
+      namespace_overrides = optional(map(object({
+        default                 = optional(map(string))
+        default_request         = optional(map(string))
+        min                     = optional(map(string))
+        max                     = optional(map(string))
+        max_limit_request_ratio = optional(map(string))
+      })), {})
+    }), {})
+    advanced = optional(object({
+      k8s = optional(map(any), {})
+    }), {})
+  })
+}
+
+variable "instance_name" {
+  type    = string
+  default = "limit-range"
+}
+
+variable "environment" {
+  description = "Environment configuration"
+  type = object({
+    namespace   = string
+    name        = optional(string)
+    unique_name = optional(string)
+    cloud_tags  = optional(map(string), {})
+  })
+  default = {
+    namespace = "default"
+  }
+}
+
+variable "inputs" {
+  description = "Input references from other modules"
+  type = object({
+    kubernetes_details = object({
+      attributes = optional(object({
+        cloud_provider   = optional(string)
+        cluster_id       = optional(string)
+        cluster_name     = optional(string)
+        cluster_location = optional(string)
+        cluster_endpoint = optional(string)
+      }))
+      interfaces = optional(object({
+        kubernetes = optional(object({
+          cluster_ca_certificate = optional(string)
+          host                   = optional(string)
+        }))
+      }))
+    })
+  })
+}


### PR DESCRIPTION
## Summary

Adds `limit_range/default/1.0` — a Facets module that creates Kubernetes LimitRange resources cluster-wide or to specific namespaces, enforcing default resource requests and limits on containers that don't set their own.

## Features

- **Two modes:**
  - `cluster_wide: true` — applies LimitRange to all namespaces (uses `data "kubernetes_all_namespaces"`), with configurable `exclude_namespaces` to skip specific ones
  - `cluster_wide: false` — applies only to explicitly listed `target_namespaces`

- **Full LimitRange spec** — configures all fields supported by `kubernetes_limit_range_v1`:
  - `default` — default limits injected if container doesn't set its own
  - `default_request` — default requests injected if container doesn't set its own
  - `min` / `max` — hard floor/ceiling, rejects pods outside the range at admission
  - `max_limit_request_ratio` — rejects pods where limit/request ratio exceeds threshold
  - All fields support `cpu`, `memory`, and `ephemeral-storage`

- **Namespace overrides** — per-namespace overrides merged on top of the base spec. Allows different limits for different namespaces (e.g., tighter limits for CI/CD namespaces, looser for workload namespaces)

## Usage example

```yaml
kind: limit_range
flavor: default
version: '1.0'
spec:
  cluster_wide: true
  exclude_namespaces:
  - kube-node-lease
  - kube-public
  limits:
    type: Container
    default_request:
      ephemeral-storage: "512Mi"
      cpu: "100m"
      memory: "128Mi"
    default:
      ephemeral-storage: "5Gi"
      cpu: "1"
      memory: "1Gi"
  namespace_overrides:
    default:
      default_request:
        ephemeral-storage: "1Gi"
      default:
        ephemeral-storage: "10Gi"
    tekton-pipelines:
      default:
        ephemeral-storage: "2Gi"
```

## Caveats

- `data "kubernetes_all_namespaces"` reads at plan time — namespaces created between applies won't get a LimitRange until the next release cycle
- Only affects new pods — existing running pods are not modified

## Test plan

- [ ] `terraform init && terraform validate` passes
- [ ] Deploy in `specific_namespaces` mode with 1-2 namespaces
- [ ] Verify LimitRange created: `kubectl get limitrange -A`
- [ ] Deploy pod without resource specs, verify defaults injected
- [ ] Test `cluster_wide` mode with `exclude_namespaces`
- [ ] Test `namespace_overrides` produces different limits per namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)