### PR TITLE
Enable Gateway API on GKE cluster

### DIFF
--- a/modules/kubernetes_cluster/gke/1.0/main.tf
+++ b/modules/kubernetes_cluster/gke/1.0/main.tf
@@ -76,6 +76,11 @@ resource "google_container_cluster" "primary" {
     workload_pool = "${local.project_id}.svc.id.goog"
   }
 
+  # Enable Gateway API (standard channel) for Gateway/HTTPRoute resources
+  gateway_api_config {
+    channel = "CHANNEL_STANDARD"
+  }
+
   # Addons configuration
   addons_config {
     http_load_balancing {


### PR DESCRIPTION
## Summary
- Add `gateway_api_config` block with `CHANNEL_STANDARD` to `google_container_cluster.primary` in `modules/kubernetes_cluster/gke/1.0/main.tf`
- Unblocks use of Gateway/HTTPRoute resources on clusters provisioned by this module

## Test plan
- [ ] `raptor create iac-module -f modules/kubernetes_cluster/gke/1.0 --dry-run` passes
- [ ] Provision a GKE cluster from this module and verify `kubectl get gatewayclasses` lists GKE-managed classes (e.g. `gke-l7-global-external-managed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)