### PR TITLE
fix output for postgresql

### DIFF
--- a/modules/datastore/postgres/kubeblocks/1.0/locals.tf
+++ b/modules/datastore/postgres/kubeblocks/1.0/locals.tf
@@ -82,8 +82,12 @@ locals {
 
   postgres_database = "postgres"
 
+  # KubeBlocks component name (matches componentSpecs[].name in main.tf)
+  component_name = "postgresql"
+
   # Writer/Primary endpoint (always exists)
-  writer_host = "${local.cluster_name}-postgresql.${local.namespace}.svc.cluster.local"
+  # KubeBlocks creates the writer service as: {cluster_name}-{component_name}-{component_name}
+  writer_host = "${local.cluster_name}-${local.component_name}-${local.component_name}.${local.namespace}.svc.cluster.local"
   writer_port = 5432
 
   # PgBouncer connection pool endpoints

--- a/modules/datastore/postgres/kubeblocks/1.0/main.tf
+++ b/modules/datastore/postgres/kubeblocks/1.0/main.tf
@@ -67,7 +67,7 @@ module "postgresql_cluster" {
         componentSpecs = [
           merge(
             {
-              name           = "postgresql"
+              name           = local.component_name
               componentDef   = local.component_def
               serviceVersion = local.postgres_version
               replicas       = local.replicas
@@ -118,7 +118,7 @@ module "postgresql_cluster" {
                               matchLabels = {
                                 "app.kubernetes.io/instance"        = local.cluster_name
                                 "app.kubernetes.io/managed-by"      = "kubeblocks"
-                                "apps.kubeblocks.io/component-name" = "postgresql"
+                                "apps.kubeblocks.io/component-name" = local.component_name
                               }
                             }
                             topologyKey = "kubernetes.io/hostname"
@@ -191,7 +191,7 @@ resource "kubernetes_pod_disruption_budget_v1" "postgresql_pdb" {
       match_labels = {
         "app.kubernetes.io/instance"        = local.cluster_name
         "app.kubernetes.io/managed-by"      = "kubeblocks"
-        "apps.kubeblocks.io/component-name" = "postgresql"
+        "apps.kubeblocks.io/component-name" = local.component_name
       }
     }
   }
@@ -210,7 +210,7 @@ resource "kubernetes_service" "postgres_read" {
     labels = {
       "app.kubernetes.io/instance"        = local.cluster_name
       "app.kubernetes.io/managed-by"      = "kubeblocks"
-      "apps.kubeblocks.io/component-name" = "postgresql"
+      "apps.kubeblocks.io/component-name" = local.component_name
       "facets.io/created-by"              = "terraform"
     }
   }
@@ -222,7 +222,7 @@ resource "kubernetes_service" "postgres_read" {
     selector = {
       "app.kubernetes.io/instance"        = local.cluster_name
       "app.kubernetes.io/managed-by"      = "kubeblocks"
-      "apps.kubeblocks.io/component-name" = "postgresql"
+      "apps.kubeblocks.io/component-name" = local.component_name
       "kubeblocks.io/role"                = "secondary"
     }
 


### PR DESCRIPTION
The postgres/kubeblocks module was generating an incorrect writer host in its outputs

Root cause: KubeBlocks creates the writer/primary service with the naming pattern {cluster_name}-{component_name}-{component_name}, but the module was constructing the host as
  {cluster_name}-{component_name} (missing the second component name suffix).
  
  ```
  ┌─────────────────────────────────┬─────────────────────────────────────────────────────┐
  │                                 │                        Host                         │
  ├─────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ Module output (before fix)      │ postgresql-sonarqube-postgres-postgresql            │
  ├─────────────────────────────────┼─────────────────────────────────────────────────────┤
  │ Actual K8s service (KubeBlocks) │ postgresql-sonarqube-postgres-postgresql-postgresql │
  └─────────────────────────────────┴─────────────────────────────────────────────────────┘
  ```
  
  Changes

  - locals.tf: Added component_name local variable, fixed writer_host to use {cluster_name}-{component_name}-{component_name} pattern
  - main.tf: Replaced all hardcoded "postgresql" component name references with local.component_name (componentSpecs[].name and apps.kubeblocks.io/component-name labels)