### PR TITLE
feat(karpenter): add additional_node_policies to attach custom IAM policies to node role

### DIFF
--- a/modules/karpenter/default/1.0/facets.yaml
+++ b/modules/karpenter/default/1.0/facets.yaml
@@ -61,6 +61,23 @@ spec:
             description: Version of Karpenter to deploy (should match your Kubernetes version)
             title: Karpenter Version
             type: string
+        additional_node_policies:
+            type: object
+            title: Additional Node IAM Policies
+            description: Additional IAM policy ARNs to attach to the Karpenter node role (e.g., for X-Ray, CloudWatch)
+            patternProperties:
+                ^[a-zA-Z0-9_.-]*$:
+                    title: Policy Name
+                    type: object
+                    properties:
+                        arn:
+                            title: ARN
+                            type: string
+                            pattern: ^(arn:aws:iam::(\d{12}|aws):policy\/[A-Za-z0-9+=,.@\-_]+|\$\{[A-Za-z0-9._-]+\})$
+                            x-ui-placeholder: 'IAM policy ARN. Eg: arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess'
+                            x-ui-error-message: 'Value doesn''t match pattern, accepted value pattern Eg: arn:aws:iam::123456789012:policy/policy1'
+                    required:
+                        - arn
         tags:
             description: Additional AWS tags to apply to Karpenter resources
             title: Resource Tags
@@ -73,5 +90,6 @@ spec:
     x-ui-order:
         - karpenter_version
         - karpenter_replicas
+        - additional_node_policies
         - tags
 version: "1.0"

--- a/modules/karpenter/default/1.0/facets.yaml
+++ b/modules/karpenter/default/1.0/facets.yaml
@@ -76,6 +76,8 @@ spec:
                             pattern: ^(arn:aws:iam::(\d{12}|aws):policy\/[A-Za-z0-9+=,.@\-_]+|\$\{[A-Za-z0-9._-]+\})$
                             x-ui-placeholder: 'IAM policy ARN. Eg: arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess'
                             x-ui-error-message: 'Value doesn''t match pattern, accepted value pattern Eg: arn:aws:iam::123456789012:policy/policy1'
+                            x-ui-output-type: iam_policy_arn
+                            x-ui-typeable: true
                     required:
                         - arn
         tags:

--- a/modules/karpenter/default/1.0/main.tf
+++ b/modules/karpenter/default/1.0/main.tf
@@ -192,12 +192,12 @@ resource "aws_iam_role" "karpenter_node" {
 
 # Attach required policies to node role
 resource "aws_iam_role_policy_attachment" "karpenter_node_policies" {
-  for_each = toset([
+  for_each = toset(concat([
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
     "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  ])
+  ], [for policy in values(var.instance.spec.additional_node_policies) : policy.arn]))
 
   role       = aws_iam_role.karpenter_node.name
   policy_arn = each.value

--- a/modules/karpenter/default/1.0/variables.tf
+++ b/modules/karpenter/default/1.0/variables.tf
@@ -9,6 +9,11 @@ variable "instance" {
       karpenter_replicas    = optional(number, 2)
       interruption_handling = optional(bool, false)
 
+      # Additional IAM policies for node role
+      additional_node_policies = optional(map(object({
+        arn = string
+      })), {})
+
       # Tags
       tags = optional(map(string), {})
     })


### PR DESCRIPTION
## Summary

- Adds `additional_node_policies` spec field to the Karpenter module, allowing users to attach custom IAM policy ARNs to the Karpenter node role via the blueprint
- Uses `patternProperties` in `facets.yaml` (consistent with the service module's `iam_policies` pattern) with ARN validation
- Updates `variables.tf` to accept `map(object({ arn = string }))` and `main.tf` to merge additional policies into the node role policy attachments

## Problem

Pods running on Karpenter-provisioned nodes inherit the Karpenter node IAM role. When services like OpenTelemetry auto-instrumentation need additional AWS permissions (e.g., `xray:PutTraceSegments`), the node role lacks those permissions, causing errors like:

```
OTLPExporterError: Internal Server Error
AccessDeniedException: User: arn:aws:sts::568521409319:assumed-role/karpenter-node-main-digifinn-8490656265-dev/i-0f117fdc7ba2b7792 
is not authorized to perform: xray:PutTraceSegments because no identity-based policy allows the xray:PutTraceSegments action
```

## Solution

Instead of hardcoding specific policies, this adds a configurable `additional_node_policies` field so users can attach any IAM policies via the blueprint:

```yaml
spec:
  additional_node_policies:
    xray:
      arn: "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
```

## Files Changed

| File | Change |
|------|--------|
| `modules/karpenter/default/1.0/facets.yaml` | Added `additional_node_policies` spec with `patternProperties` and ARN validation |
| `modules/karpenter/default/1.0/variables.tf` | Added `additional_node_policies` as `optional(map(object({ arn = string })), {})` |
| `modules/karpenter/default/1.0/main.tf` | Merged additional policy ARNs into `karpenter_node_policies` `for_each` |

## Test plan

- [ ] Validate module with `raptor create iac-module -f modules/karpenter/default/1.0 --dry-run`
- [ ] Deploy with `additional_node_policies` containing `AWSXRayDaemonWriteAccess` and verify the OTEL exporter error is resolved
- [ ] Deploy without `additional_node_policies` to confirm backward compatibility (empty map default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)