### PR TITLE
fix(eks): add IRSA role for CloudWatch Agent and support custom IAM policies

### DIFF
--- a/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
@@ -282,6 +282,27 @@ spec:
             description: Enable CloudWatch Container Insights for cluster monitoring.
             title: Container Insights
             type: boolean
+        cloudwatch_agent_policies:
+            type: object
+            title: CloudWatch Agent IAM Policies
+            description: Additional IAM policy ARNs to attach to the CloudWatch Agent IRSA role (e.g., for X-Ray, custom metrics)
+            x-ui-visible-if:
+                field: spec.container_insights_enabled
+                values:
+                    - true
+            patternProperties:
+                ^[a-zA-Z0-9_.-]*$:
+                    title: Policy Name
+                    type: object
+                    properties:
+                        arn:
+                            title: ARN
+                            type: string
+                            pattern: ^(arn:aws:iam::(\d{12}|aws):policy\/[A-Za-z0-9+=,.@\-_]+|\$\{[A-Za-z0-9._-]+\})$
+                            x-ui-placeholder: 'IAM policy ARN. Eg: arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess'
+                            x-ui-error-message: 'Value doesn''t match pattern, accepted value pattern Eg: arn:aws:iam::123456789012:policy/policy1'
+                    required:
+                        - arn
         customer_managed_kms:
             default: true
             description: Use a customer-managed KMS key for Kubernetes secrets encryption. Required for compliance (PCI-DSS, HIPAA). EKS always encrypts secrets with AWS-owned keys by default.
@@ -317,6 +338,7 @@ spec:
         - customer_managed_kms
         - enabled_log_types
         - container_insights_enabled
+        - cloudwatch_agent_policies
         - cluster_addons
         - default_node_pool
         - cluster_tags

--- a/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
@@ -301,6 +301,8 @@ spec:
                             pattern: ^(arn:aws:iam::(\d{12}|aws):policy\/[A-Za-z0-9+=,.@\-_]+|\$\{[A-Za-z0-9._-]+\})$
                             x-ui-placeholder: 'IAM policy ARN. Eg: arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess'
                             x-ui-error-message: 'Value doesn''t match pattern, accepted value pattern Eg: arn:aws:iam::123456789012:policy/policy1'
+                            x-ui-output-type: iam_policy_arn
+                            x-ui-typeable: true
                     required:
                         - arn
         customer_managed_kms:

--- a/modules/kubernetes_cluster/eks_standard/1.0/main.tf
+++ b/modules/kubernetes_cluster/eks_standard/1.0/main.tf
@@ -84,7 +84,7 @@ locals {
     amazon-cloudwatch-observability = local.container_insights_enabled ? {
       addon_version            = null
       resolve_conflicts        = "OVERWRITE"
-      service_account_role_arn = null
+      service_account_role_arn = local.needs_cloudwatch_iam_policy ? aws_iam_role.cloudwatch_agent_irsa[0].arn : null
     } : null
 
     metrics-server = lookup(lookup(var.instance.spec.cluster_addons, "metrics_server", {}), "enabled", true) ? {
@@ -224,4 +224,43 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent" {
 
   role       = each.value.iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# IAM Role for CloudWatch Agent (IRSA)
+resource "aws_iam_role" "cloudwatch_agent_irsa" {
+  count = local.needs_cloudwatch_iam_policy ? 1 : 0
+
+  name = "${local.cluster_name}-cw-agent"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = module.eks.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${module.eks.oidc_provider}:aud" = "sts.amazonaws.com"
+            "${module.eks.oidc_provider}:sub" = "system:serviceaccount:amazon-cloudwatch:cloudwatch-agent"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.cluster_tags
+}
+
+# Attach CloudWatchAgentServerPolicy and any additional user-provided policies to IRSA role
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_irsa" {
+  for_each = local.needs_cloudwatch_iam_policy ? toset(concat(
+    ["arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"],
+    [for policy in values(lookup(var.instance.spec, "cloudwatch_agent_policies", {})) : policy.arn]
+  )) : toset([])
+
+  role       = aws_iam_role.cloudwatch_agent_irsa[0].name
+  policy_arn = each.value
 }

--- a/modules/kubernetes_cluster/eks_standard/1.0/variables.tf
+++ b/modules/kubernetes_cluster/eks_standard/1.0/variables.tf
@@ -36,6 +36,10 @@ variable "instance" {
 
       container_insights_enabled = optional(bool, false)
 
+      cloudwatch_agent_policies = optional(map(object({
+        arn = string
+      })), {})
+
       enabled_log_types = optional(list(string), ["api", "audit", "authenticator", "controllerManager", "scheduler"])
 
       cluster_tags = optional(map(string), {})


### PR DESCRIPTION
## Summary

- Adds a dedicated IRSA role for the CloudWatch Agent (`amazon-cloudwatch:cloudwatch-agent` service account) when Container Insights is enabled
- Passes the IRSA role ARN to the `amazon-cloudwatch-observability` addon via `service_account_role_arn`
- Adds a configurable `cloudwatch_agent_policies` spec field (using `patternProperties`) so users can attach additional IAM policies to the CloudWatch Agent IRSA role
- **Retains** the existing node-level `CloudWatchAgentServerPolicy` attachment on managed node groups to avoid breaking existing customers

## Problem

The `amazon-cloudwatch-observability` EKS addon had `service_account_role_arn = null`, causing the CloudWatch Agent to fall back to the **node IAM role** for all AWS API calls. This caused two issues:

1. **Karpenter nodes**: CloudWatch Agent pods on Karpenter-provisioned nodes had no CloudWatch/X-Ray permissions since only managed node group roles had `CloudWatchAgentServerPolicy` attached
2. **X-Ray traces**: The addon injects OTEL auto-instrumentation into all pods via a mutating webhook (`mpod.kb.io`). Traces are sent to the CloudWatch Agent which forwards to X-Ray, but `AWSXRayDaemonWriteAccess` was never attached to any role, causing:
   ```
   OTLPExporterError: Internal Server Error
   AccessDeniedException: xray:PutTraceSegments
   ```

## Solution

Create an IRSA role for the CloudWatch Agent (same pattern as the existing EBS CSI driver IRSA), so it gets permissions via the service account regardless of which node type it runs on.

**Architecture:**
```
                    Before                                    After
CloudWatch Agent → node IAM role → ❌ (no X-Ray)   CloudWatch Agent → IRSA role → ✅ (CW + X-Ray + custom)
                   (only on managed nodes)                            (works on all nodes)
```

**Usage** - to fix X-Ray errors, add to blueprint:
```yaml
spec:
  container_insights_enabled: true
  cloudwatch_agent_policies:
    xray:
      arn: "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
```

## Files Changed

| File | Change |
|------|--------|
| `main.tf` | Added IRSA role for `amazon-cloudwatch:cloudwatch-agent` SA, policy attachments, and wired `service_account_role_arn` to addon config. Kept existing node-level policy attachment unchanged. |
| `variables.tf` | Added `cloudwatch_agent_policies` as `optional(map(object({ arn = string })), {})` |
| `facets.yaml` | Added `cloudwatch_agent_policies` with `patternProperties` and ARN validation, visible when `container_insights_enabled` is true |

## Backward Compatibility

- Existing `cloudwatch_agent` resource (node-level policy attachment) is **untouched** — same resource name, same logic
- New IRSA resources use `cloudwatch_agent_irsa` suffix to avoid state conflicts
- `cloudwatch_agent_policies` defaults to `{}`, so existing customers with no custom policies are unaffected

## Test plan

- [ ] Validate module with `raptor create iac-module -f modules/kubernetes_cluster/eks_standard/1.0 --dry-run`
- [ ] Deploy on a cluster with `container_insights_enabled: true` and verify CloudWatch Agent uses the IRSA role
- [ ] Add `AWSXRayDaemonWriteAccess` via `cloudwatch_agent_policies` and verify OTEL trace export to X-Ray works on both managed and Karpenter nodes
- [ ] Deploy without `cloudwatch_agent_policies` to confirm backward compatibility
- [ ] Verify existing managed node groups still have `CloudWatchAgentServerPolicy` on their node roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)