### PR TITLE
feat(ingress/fabric): expose legacy_resource_details from utility module

### DIFF
--- a/modules/ingress/nginx_gateway_fabric_aws/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_aws/1.0/outputs.tf
@@ -47,3 +47,7 @@ output "load_balancer_ip" {
   value       = module.nginx_gateway_fabric.load_balancer_ip
   description = "Load balancer IP address (for A records)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}

--- a/modules/ingress/nginx_gateway_fabric_azure/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_azure/1.0/outputs.tf
@@ -47,3 +47,7 @@ output "load_balancer_ip" {
   value       = module.nginx_gateway_fabric.load_balancer_ip
   description = "Load balancer IP address (for A records)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}

--- a/modules/ingress/nginx_gateway_fabric_gcp/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_gcp/1.0/outputs.tf
@@ -47,3 +47,7 @@ output "load_balancer_ip" {
   value       = module.nginx_gateway_fabric.load_balancer_ip
   description = "Load balancer IP address (for A records)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}

--- a/modules/ingress/nginx_gateway_fabric_ovh/1.0/outputs.tf
+++ b/modules/ingress/nginx_gateway_fabric_ovh/1.0/outputs.tf
@@ -47,3 +47,7 @@ output "load_balancer_ip" {
   value       = module.nginx_gateway_fabric.load_balancer_ip
   description = "Load balancer IP address (for A records)"
 }
+
+output "legacy_resource_details" {
+  value = module.nginx_gateway_fabric.legacy_resource_details
+}


### PR DESCRIPTION
## Summary
- Re-exports `module.nginx_gateway_fabric.legacy_resource_details` from all four fabric wrapper flavors (`aws`, `azure`, `gcp`, `ovh`).
- Required because Terraform module outputs do **not** auto-passthrough — without these declarations the utility module's `legacy_resource_details` output is invisible to consumers.
- Downstream effect: `level2/legacy.tf` in `facets-iac` does `lookup(local.module_<key>, "legacy_resource_details", [])` — until this output exists on the wrapper it falls back to `[]` and the Facets UI shows nothing for ingress resource values (basic auth password, base domain, per-rule domains).

## Files (4 × 4-line additions)
- `modules/ingress/nginx_gateway_fabric_aws/1.0/outputs.tf`
- `modules/ingress/nginx_gateway_fabric_azure/1.0/outputs.tf`
- `modules/ingress/nginx_gateway_fabric_gcp/1.0/outputs.tf`
- `modules/ingress/nginx_gateway_fabric_ovh/1.0/outputs.tf`

```hcl
output "legacy_resource_details" {
  value = module.nginx_gateway_fabric.legacy_resource_details
}
```

## Test plan
- [ ] Republish each wrapper module via the Facets control plane after merge so the S3 zip picks up the new output.
- [ ] Trigger a release on environments using each flavor (aws, azure, gcp, ovh) and confirm the Facets UI ingress resource-values panel shows: Basic Authentication Password (when `basic_auth: true`), Base Domain, and one row per rule.
- [ ] Verify `terraform output -json | jq '.legacy_resource_details.value'` after apply contains entries with `resource_type = "ingress"` / `resource_type = "ingress_rules_infra"`.
- [ ] Confirm no "Provider produced inconsistent final plan" error on first apply (when basic_auth password is generated).

## Dependency
Depends on [facets-utility-modules#35](https://github.com/Facets-cloud/facets-utility-modules/pull/35) (merged) which adds `legacy_resource_details` to the underlying utility module. Companion PR for the legacy variants is [facets-modules#548](https://github.com/Facets-cloud/facets-modules/pull/548).

🤖 Generated with [Claude Code](https://claude.com/claude-code)