### PR TITLE
fix(eks_standard): break terraform locals cycle in cluster addons

### DIFF
--- a/modules/kubernetes_cluster/eks_standard/1.0/main.tf
+++ b/modules/kubernetes_cluster/eks_standard/1.0/main.tf
@@ -119,7 +119,7 @@ locals {
 
   # Container Insights
   container_insights_enabled  = lookup(var.instance.spec, "container_insights_enabled", false)
-  needs_cloudwatch_iam_policy = contains(keys(local.enabled_cluster_addons), "amazon-cloudwatch-observability")
+  needs_cloudwatch_iam_policy = local.container_insights_enabled
 
   # KMS key for secrets encryption (only if enabled)
   enable_kms_key = lookup(var.instance.spec, "customer_managed_kms", true)


### PR DESCRIPTION
## Summary
- `terraform validate` failed with `Cycle: aws_iam_role.cloudwatch_agent_irsa → local.needs_cloudwatch_iam_policy → local.enabled_cluster_addons → local.cluster_addons_config → local.default_addons → aws_iam_role.cloudwatch_agent_irsa`.
- `local.default_addons` references `aws_iam_role.cloudwatch_agent_irsa[0].arn`, while the role's `count` depended on `needs_cloudwatch_iam_policy`, which was derived from `enabled_cluster_addons` (built from `default_addons`).
- Source `needs_cloudwatch_iam_policy` directly from `local.container_insights_enabled` (spec input). That flag already gates inclusion of the `amazon-cloudwatch-observability` addon in `default_addons`, so semantics are unchanged.

## Test plan
- [x] `raptor create iac-module -f . --dry-run` — terraform validate passes (security scan failures are pre-existing and out of scope)
- [ ] Reviewer: confirm cloudwatch IRSA role still created iff `container_insights_enabled = true`