### PR TITLE
feat: EKS 1.35 upgrade — eks_standard default + version enum

### DIFF
--- a/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
@@ -89,7 +89,7 @@ sample:
                 version: latest
         cluster_endpoint_private_access: true
         cluster_endpoint_public_access: true
-        cluster_version: "1.34"
+        cluster_version: "1.35"
         customer_managed_kms: true
     version: "1.1"
 spec:
@@ -228,7 +228,7 @@ spec:
             type: object
             x-ui-yaml-editor: true
         cluster_version:
-            default: "1.34"
+            default: "1.35"
             description: EKS Kubernetes version
             enum:
                 - "1.28"
@@ -239,6 +239,8 @@ spec:
                 - "1.33"
                 - "1.34"
                 - "1.35"
+                - "1.36"
+                - "1.37"
             title: Kubernetes Version
             type: string
             x-ui-overrides-only: true


### PR DESCRIPTION
## What

Upgrades the `kubernetes_cluster/eks_standard` module to Kubernetes **1.35** and fixes a version-list inconsistency.

| Change | File | Before | After |
|---|---|---|---|
| Sample `cluster_version` | `eks_standard/1.0/facets.yaml:92` | `1.34` | `1.35` |
| Spec **default** `cluster_version` | `eks_standard/1.0/facets.yaml:231` | `1.34` | `1.35` |
| Version **enum** | `eks_standard/1.0/facets.yaml:233-241` | capped at `1.35` | adds `1.36`, `1.37` |

## Why

- Brings the redesign catalog in line with the EKS/AKS **1.35** rollout already shipped in `facets-iac` (#2100, #2103).
- The facets.yaml enum was out of sync with `variables.tf:50`, whose `contains([...])` validation already allows `1.28`–`1.37`. Users couldn't select `1.36`/`1.37` in the UI even though the module accepted them. Extending the enum resolves the mismatch.

## Why this is the *only* code change needed

This catalog is forward-compatible by design — the rest of the fleet needs no edits for 1.35:

- **eks_automode** — does not expose `cluster_version` (AWS Auto Mode manages it).
- **aks / gke / ovh** — cloud-managed via upgrade channels; no version enum.
- **lke** already defaults to `1.35`; **vke** already `v1.35.0+1`.
- **karpenter node pool** already hardcodes `AL2023` (correct for K8s 1.33+).
- **EKS addons** (vpc-cni, coredns, kube-proxy, ebs-csi, metrics-server) all default to `latest` — AWS auto-manages them per cluster version.

## Verify-only (no code change; user-controllable defaults, flagged for awareness)

Confirm compatibility with K8s 1.35 — these have no enum, users set them:
- Karpenter controller `1.5.0`
- AWS ALB controller `3.0.0`
- EFS CSI driver `2.4.6`
- ACK ACM controller `1.3.4`

## Validation

`raptor create iac-module --dry-run`:
- ✅ **Terraform validation successful** (schema/structure — the part this change touches).
- ⚠️ Security scan reports **2 pre-existing** HIGH/CRITICAL findings unrelated to this version bump:
  - `AWS-0039` (HIGH) — EKS secret encryption not enabled — `main.tf:35-188`
  - `AWS-0104` (CRITICAL) — security group allows unrestricted egress — `main.tf:250`

  These exist in the vendored `aws-terraform-eks` module independent of this change. Out of scope for a version upgrade; left for a dedicated hardening PR.

## Test plan
- [ ] Confirm `1.35` default renders in the module UI dropdown with `1.36`/`1.37` selectable
- [ ] Launch an `eks_standard` cluster at `1.35` on a dev environment
- [ ] (separate) Address the two pre-existing security findings