### PR TITLE
fix(helm/k8s_standard): use metadata object for values output

### DIFF
--- a/modules/common/helm/k8s_standard/1.0/outputs.tf
+++ b/modules/common/helm/k8s_standard/1.0/outputs.tf
@@ -1,7 +1,7 @@
 locals {
   output_attributes = {
     release_name = helm_release.external_helm_charts.name
-    values       = jsondecode(helm_release.external_helm_charts.metadata[0].values)
+    values       = jsondecode(helm_release.external_helm_charts.metadata.values)
   }
   output_interfaces = {}
 }


### PR DESCRIPTION
## Problem
`raptor create iac-module --publish` fails terraform validate on `outputs.tf:4`:

```
Error: Invalid index
The given key does not identify an element in this collection value.
An object only supports looking up attributes by name, not by numeric index.
```

## Cause
Helm provider **v3** changed `helm_release.metadata` from a **list** to a single **object**. The `metadata[0]` numeric index is no longer valid.

## Fix
```diff
-    values = jsondecode(helm_release.external_helm_charts.metadata[0].values)
+    values = jsondecode(helm_release.external_helm_charts.metadata.values)
```

## Verification
`raptor create iac-module -f . --publish` (full validation, no skip) passes:
- 🔍 Terraform validation successful
- ✅ Output types validated successfully
- ✓ Module published (Stage: PUBLISHED) on capillary CP