### PR TITLE
fix(datastore/mysql/aws-rds): drop dead master_username spec field

### DIFF
--- a/modules/datastore/mysql/aws-rds/1.0/variables.tf
+++ b/modules/datastore/mysql/aws-rds/1.0/variables.tf
@@ -6,9 +6,8 @@ variable "instance" {
     version = string
     spec = object({
       version_config = object({
-        version         = string
-        database_name   = string
-        master_username = string
+        version       = string
+        database_name = string
       })
       sizing = object({
         instance_class        = string
@@ -68,10 +67,6 @@ variable "instance" {
     error_message = "Database name must be between 1 and 64 characters"
   }
 
-  validation {
-    condition     = length(var.instance.spec.version_config.master_username) >= 1 && length(var.instance.spec.version_config.master_username) <= 16
-    error_message = "Master username must be between 1 and 16 characters"
-  }
 }
 
 variable "instance_name" {


### PR DESCRIPTION
## What
Removes the `master_username` field (and its length validation) from the user-facing `version_config` spec of the MySQL AWS-RDS module.

## Why
`master_username` was never wired to the resource from spec — `locals.tf` already derives it: `"admin"` for new instances, or `restore_master_username` for restore operations. Exposing it in `version_config` was dead and misleading: setting it had no effect.

## Changes
- `variables.tf`: drop `master_username` from `version_config` object and remove its 1–16 char validation block.

`facets.yaml` (spec, x-ui-order, sample) already contained no `master_username` under `version_config`, so no schema change was needed.

## Validation
- No remaining references to `version_config.master_username` in the module.
- Restore path (`restore_master_username`) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)