### PR TITLE
fix(datastore/mysql/aws-rds): rename input aws_cloud_account → aws_provider

### DIFF
--- a/modules/datastore/mysql/aws-rds/1.0/facets.yaml
+++ b/modules/datastore/mysql/aws-rds/1.0/facets.yaml
@@ -1,6 +1,6 @@
 intent: mysql
 flavor: aws-rds
-version: '1.0'
+version: '1.1'
 clouds:
 - aws
 description: Managed MySQL database instance on AWS RDS with high availability, automated
@@ -212,7 +212,7 @@ imports:
   resource_address: random_password.master_password[0]
   required: true
 inputs:
-  aws_cloud_account:
+  aws_provider:
     type: '@facets/aws_cloud_account'
     optional: false
     displayName: AWS Cloud Account
@@ -236,7 +236,7 @@ iac:
 sample:
   kind: mysql
   flavor: aws-rds
-  version: '1.0'
+  version: '1.1'
   disabled: true
   spec:
     version_config:

--- a/modules/datastore/mysql/aws-rds/1.0/variables.tf
+++ b/modules/datastore/mysql/aws-rds/1.0/variables.tf
@@ -91,7 +91,7 @@ variable "environment" {
 variable "inputs" {
   description = "A map of inputs requested by the module developer."
   type = object({
-    aws_cloud_account = object({
+    aws_provider = object({
       attributes = object({
         aws_iam_role = string
         session_name = string


### PR DESCRIPTION
## What
Renames the cloud-account input key in `mysql/aws-rds` from `aws_cloud_account` to `aws_provider`, and bumps the module version `1.0` → `1.1`.

## Why
All three AWS datastore modules depend on the same `@facets/aws_cloud_account` resource for provider setup, but named the input differently:

| Module | Input key (before) |
|--------|--------------------|
| `mysql/aws-rds` | `aws_cloud_account` ← outlier |
| `postgres/aws-rds` | `aws_provider` |
| `redis/aws-elasticache` | `aws_provider` |

This forced different `--input` wiring per module for the *same* cloud account, broke copy-paste between siblings, and tripped the 2026-06-24 AWS validation run. `aws_provider` also matches the cross-cloud convention (`gcp_provider`, `azure_provider`).

## Changes
- `variables.tf`: rename input key `aws_cloud_account` → `aws_provider` (not referenced in `.tf` code — provider-wiring only).
- `facets.yaml`: rename the input key; bump `version` (module + sample) `1.0` → `1.1`.

The output **type** `@facets/aws_cloud_account` is unchanged — only the input key name changed.

## Compatibility
Input keys are part of the module contract, so this is backward-incompatible. Version bumped to `1.1` for safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)