### PR TITLE
fix(datastore/postgres/gcp-cloudsql): read project_id, not project

### DIFF
--- a/modules/datastore/postgres/gcp-cloudsql/1.0/variables.tf
+++ b/modules/datastore/postgres/gcp-cloudsql/1.0/variables.tf
@@ -82,7 +82,7 @@ variable "inputs" {
   type = object({
     gcp_provider = object({
       attributes = object({
-        project     = string
+        project_id  = string
         credentials = string
       })
     })


### PR DESCRIPTION
## What
Renames the `gcp_provider.attributes` field read by `postgres/gcp-cloudsql` from `project` to `project_id`.

## Why
All three GCP datastore modules consume the same `@facets/gcp_cloud_account` provider input, but read different attribute names:

| Module | Attribute (before) |
|--------|--------------------|
| `mysql/gcp-cloudsql` | `project_id` |
| `redis/gcp-memorystore` | `project_id` |
| `postgres/gcp-cloudsql` | `project` ← drifted |

Both names resolve today only because the resource-type system passes the whole `@facets/gcp_cloud_account` interface object through. The inconsistency breaks the moment the output schema is tightened to require one canonical name. `project_id` matches the two siblings and standard GCP API parameter naming.

## Changes
- `variables.tf`: `project` → `project_id` in the `gcp_provider` input type. Non-behavioral — the attribute isn't read in `.tf` code; this just makes the declared input shape consistent across siblings.

Verified: no GCP datastore module reads `attributes.project` (non-`_id`) anywhere.

## Follow-up (out of scope)
If `@facets/gcp_cloud_account` exposes both `project` and `project_id` as a back-compat artifact, drop `project` from the output type once no module reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)