### PR TITLE
fix(datastore): make restore_config optional() to match x-ui-overrides-only

### DIFF
--- a/modules/datastore/mysql/aws-rds/1.0/variables.tf
+++ b/modules/datastore/mysql/aws-rds/1.0/variables.tf
@@ -17,12 +17,12 @@ variable "instance" {
         storage_type          = string
         read_replica_count    = number
       })
-      restore_config = object({
+      restore_config = optional(object({
         restore_from_backup           = bool
         source_db_instance_identifier = optional(string)
         restore_master_username       = optional(string)
         restore_master_password       = optional(string)
-      })
+      }), { restore_from_backup = false })
       imports = optional(object({
         import_existing        = optional(bool, false)
         db_instance_identifier = optional(string)

--- a/modules/datastore/mysql/flexible_server/1.0/variables.tf
+++ b/modules/datastore/mysql/flexible_server/1.0/variables.tf
@@ -18,13 +18,13 @@ variable "instance" {
         storage_tier       = string
         read_replica_count = number
       })
-      restore_config = object({
+      restore_config = optional(object({
         restore_from_backup    = optional(bool)
         source_server_id       = optional(string)
         restore_point_in_time  = optional(string)
         administrator_login    = optional(string)
         administrator_password = optional(string)
-      })
+      }), {})
       imports = optional(object({
         import_existing  = optional(bool, false)
         server_id        = optional(string)

--- a/modules/datastore/mysql/gcp-cloudsql/1.0/variables.tf
+++ b/modules/datastore/mysql/gcp-cloudsql/1.0/variables.tf
@@ -14,12 +14,12 @@ variable "instance" {
         disk_size          = number
         read_replica_count = number
       })
-      restore_config = object({
+      restore_config = optional(object({
         restore_from_backup = bool
         source_instance_id  = optional(string)
         master_username     = optional(string)
         master_password     = optional(string)
-      })
+      }), { restore_from_backup = false })
       imports = optional(object({
         import_existing = optional(bool, false)
         instance_name   = optional(string)

--- a/modules/datastore/postgres/aws-rds/1.0/variables.tf
+++ b/modules/datastore/postgres/aws-rds/1.0/variables.tf
@@ -17,12 +17,12 @@ variable "instance" {
       security_config = object({
         deletion_protection = bool
       })
-      restore_config = object({
+      restore_config = optional(object({
         restore_from_backup           = bool
         source_db_instance_identifier = optional(string)
         master_username               = optional(string)
         master_password               = optional(string)
-      })
+      }), { restore_from_backup = false })
       imports = optional(object({
         import_existing        = optional(bool, false)
         db_instance_identifier = optional(string)

--- a/modules/datastore/postgres/gcp-cloudsql/1.0/variables.tf
+++ b/modules/datastore/postgres/gcp-cloudsql/1.0/variables.tf
@@ -14,12 +14,12 @@ variable "instance" {
         disk_size          = number
         read_replica_count = number
       })
-      restore_config = object({
+      restore_config = optional(object({
         restore_from_backup = bool
         source_instance_id  = optional(string)
         master_username     = optional(string)
         master_password     = optional(string)
-      })
+      }), { restore_from_backup = false })
       network_config = optional(object({
         ipv4_enabled = optional(bool, false)
         require_ssl  = optional(bool, true)

--- a/modules/datastore/redis/gcp-memorystore/1.0/variables.tf
+++ b/modules/datastore/redis/gcp-memorystore/1.0/variables.tf
@@ -15,10 +15,10 @@ variable "instance" {
         memory_size_gb = number
         tier           = string
       })
-      restore_config = object({
+      restore_config = optional(object({
         restore_from_backup = bool
         source_instance_id  = optional(string)
-      })
+      }), { restore_from_backup = false })
       security = object({
         enable_tls = bool
       })


### PR DESCRIPTION
## What
Wraps `restore_config` in `optional(...)` with safe defaults across 6 datastore modules.

## Why
These modules mark `restore_config` as `x-ui-overrides-only: true` in `facets.yaml` (so it isn't a primary spec field), but declared it as a **non-optional** attribute in `variables.tf`. The result:

- A spec that omits `restore_config` **passes** schema validation.
- Server-side `terraform plan` then **fails**: `attribute "restore_config" is required`.

The caller got no signal until plan time that a schema-passing spec was incomplete. Surfaced during the 2026-06-24 multi-cloud validation run (worked around at apply time by setting the block explicitly).

## Changes
`restore_config = object({...})` → `restore_config = optional(object({...}), <default>)`:

| Module | Default |
|--------|---------|
| `mysql/aws-rds` | `{ restore_from_backup = false }` |
| `postgres/aws-rds` | `{ restore_from_backup = false }` |
| `mysql/gcp-cloudsql` | `{ restore_from_backup = false }` |
| `postgres/gcp-cloudsql` | `{ restore_from_backup = false }` |
| `redis/gcp-memorystore` | `{ restore_from_backup = false }` |
| `mysql/flexible_server` (azure) | `{}` (all fields already optional) |

Existing validation blocks (mysql/gcp-cloudsql, mysql/flexible_server) already short-circuit on the no-restore path, so behavior is unchanged when the block **is** provided.

## Scope notes
- `imports` was already `optional()` in every module — no change needed.
- `postgres/azure-flexible-server` and `redis/aws-elasticache` were already clean.
- `redis/gcp-memorystore` had the same drift (not in the original ticket) — included here.
- `terraform fmt -check` passes on all 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)