### PR TITLE
fix(kubeblocks): lookup-safe optional fields, dead-code toggles, output schema fixes

### DIFF
--- a/modules/common/kubeblocks-operator/standard/1.0/facets.yaml
+++ b/modules/common/kubeblocks-operator/standard/1.0/facets.yaml
@@ -79,6 +79,36 @@ spec:
           title: Memory Request
           description: Memory request for KubeBlocks controller
           default: 512Mi
+    database_addons:
+      type: object
+      title: Database Addons
+      description: Toggle which KubeBlocks database engine addons are installed. Disabled engines are not installed at all.
+      properties:
+        postgresql:
+          type: boolean
+          title: PostgreSQL
+          description: Install the PostgreSQL KubeBlocks addon
+          default: true
+        mysql:
+          type: boolean
+          title: MySQL
+          description: Install the MySQL KubeBlocks addon
+          default: true
+        mongodb:
+          type: boolean
+          title: MongoDB
+          description: Install the MongoDB KubeBlocks addon
+          default: true
+        redis:
+          type: boolean
+          title: Redis
+          description: Install the Redis KubeBlocks addon
+          default: true
+        kafka:
+          type: boolean
+          title: Kafka
+          description: Install the Kafka KubeBlocks addon
+          default: true
   required:
   - version
 outputs:

--- a/modules/common/kubeblocks-operator/standard/1.0/install_crds.tf
+++ b/modules/common/kubeblocks-operator/standard/1.0/install_crds.tf
@@ -73,7 +73,7 @@ resource "kubernetes_job" "install_crds" {
 
         container {
           name    = "apply-crds"
-          image   = "bitnamilegacy/kubectl:1.33.4"
+          image   = "registry.k8s.io/kubectl:v1.33.4"
           command = ["kubectl", "apply", "--server-side", "--force-conflicts", "-f", "/crds/kubeblocks_crds.yaml"]
 
           volume_mount {

--- a/modules/common/kubeblocks-operator/standard/1.0/main.tf
+++ b/modules/common/kubeblocks-operator/standard/1.0/main.tf
@@ -163,8 +163,13 @@ locals {
     }
   }
 
-  # Filter only enabled addons
-  enabled_addons = local.addon_configs
+  # Filter to only the addons the user enabled via spec.database_addons.
+  # Each toggle defaults to true (see variables.tf), so unset = install all,
+  # preserving behavior for deployments that never set this field.
+  enabled_addons = {
+    for k, v in local.addon_configs : k => v
+    if lookup(var.instance.spec.database_addons, k, true)
+  }
 }
 
 # Install each enabled addon as a separate Helm release

--- a/modules/common/kubeblocks-operator/standard/1.0/variables.tf
+++ b/modules/common/kubeblocks-operator/standard/1.0/variables.tf
@@ -14,18 +14,23 @@ variable "instance" {
         enable_pdb = false
       })
       resources = optional(object({
-        cpu_limit      = optional(string)
-        memory_limit   = optional(string)
-        cpu_request    = optional(string)
-        memory_request = optional(string)
-      }))
+        cpu_limit      = optional(string, "1000m")
+        memory_limit   = optional(string, "1Gi")
+        cpu_request    = optional(string, "500m")
+        memory_request = optional(string, "512Mi")
+        }), {
+        cpu_limit      = "1000m"
+        memory_limit   = "1Gi"
+        cpu_request    = "500m"
+        memory_request = "512Mi"
+      })
       database_addons = optional(object({
-        postgresql = optional(bool)
-        mysql      = optional(bool)
-        mongodb    = optional(bool)
-        redis      = optional(bool)
-        kafka      = optional(bool)
-      }))
+        postgresql = optional(bool, true)
+        mysql      = optional(bool, true)
+        mongodb    = optional(bool, true)
+        redis      = optional(bool, true)
+        kafka      = optional(bool, true)
+      }), {})
     })
   })
 }
@@ -48,16 +53,8 @@ variable "inputs" {
   description = "A map of inputs requested by the module developer."
   type = object({
     kubernetes_cluster = object({
-      attributes = optional(object({
-        cluster_name   = optional(string)
-        region         = optional(string)
-        legacy_outputs = optional(any)
-      }))
-      interfaces = optional(object({
-        kubernetes_host                   = optional(string)
-        kubernetes_cluster_ca_certificate = optional(string)
-        kubernetes_token                  = optional(string)
-      }))
+      cluster_name = optional(string)
+      region       = optional(string)
     }),
     node_pool = optional(object({
       attributes = object({
@@ -74,7 +71,7 @@ variable "inputs" {
         # Node labels used as nodeSelector
         node_selector = optional(map(string), {})
       })
-      interfaces = any
+      interfaces = optional(object({}), {})
     }))
   })
 }

--- a/modules/datastore/mongo/kubeblocks/1.0/facets.yaml
+++ b/modules/datastore/mongo/kubeblocks/1.0/facets.yaml
@@ -1,6 +1,6 @@
 intent: mongo
 flavor: kubeblocks
-version: '1.1'
+version: '1.2'
 clouds:
 - kubernetes
 - aws
@@ -136,6 +136,7 @@ spec:
       description: Persistent storage settings for MongoDB data
       x-ui-order:
       - size
+      - storage_class
       properties:
         size:
           type: string
@@ -143,6 +144,12 @@ spec:
           description: Size of persistent volume (can be expanded later via volume
             expansion, cannot be reduced)
           default: 20Gi
+        storage_class:
+          type: string
+          title: Storage Class
+          description: (Optional) Kubernetes StorageClass name for the persistent
+            volume. Leave empty to use the cluster's default StorageClass.
+          default: ''
       required:
       - size
     high_availability:
@@ -267,7 +274,7 @@ iac:
 sample:
   kind: mongo
   flavor: kubeblocks
-  version: '1.1'
+  version: '1.2'
   disabled: true
   spec:
     namespace_override: ''

--- a/modules/datastore/mongo/kubeblocks/1.0/locals.tf
+++ b/modules/datastore/mongo/kubeblocks/1.0/locals.tf
@@ -54,11 +54,10 @@ locals {
   backup_method = "volume-snapshot"
 
   # Restore configuration - annotation-based restore from backup
-  restore_config  = lookup(var.instance.spec, "restore", {})
-  restore_enabled = lookup(local.restore_config, "enabled", false) == true
+  restore_enabled = try(var.instance.spec.restore.enabled, false) == true
 
   # Restore source details
-  restore_backup_name = lookup(local.restore_config, "backup_name", "")
+  restore_backup_name = try(var.instance.spec.restore.backup_name, "")
 
   # Component definition and version
   mongodb_version = var.instance.spec.mongodb_version

--- a/modules/datastore/mongo/kubeblocks/1.0/main.tf
+++ b/modules/datastore/mongo/kubeblocks/1.0/main.tf
@@ -228,8 +228,6 @@ data "kubernetes_secret" "mongodb_credentials" {
     name      = try(data.kubernetes_resources.mongodb_secrets.objects[0].metadata.name, "${local.cluster_name}-mongodb-account-root")
     namespace = local.namespace
   }
-
-  depends_on = [data.kubernetes_resources.mongodb_secrets]
 }
 
 # Data Source: Primary Service

--- a/modules/datastore/mongo/kubeblocks/1.0/variables.tf
+++ b/modules/datastore/mongo/kubeblocks/1.0/variables.tf
@@ -51,9 +51,9 @@ variable "instance" {
       }))
 
       restore = optional(object({
-        enabled     = optional(bool)
-        backup_name = optional(string)
-      }))
+        enabled     = optional(bool, false)
+        backup_name = optional(string, "")
+      }), { enabled = false, backup_name = "" })
 
       external_access = optional(map(object({
         annotations = optional(map(string), {})
@@ -73,12 +73,11 @@ variable "inputs" {
         chart_version = optional(string)
         release_id    = optional(string)
       }))
+      interfaces = optional(object({}), {})
     })
     kubernetes_cluster = object({
-      attributes = optional(object({
-        cluster_name = optional(string)
-        region       = optional(string)
-      }))
+      cluster_name = optional(string)
+      region       = optional(string)
     })
     node_pool = optional(object({
       attributes = object({
@@ -95,7 +94,7 @@ variable "inputs" {
         # Node labels used as nodeSelector
         node_selector = optional(map(string), {})
       })
-      interfaces = any
+      interfaces = optional(object({}), {})
     }))
   })
 }

--- a/modules/datastore/mysql/kubeblocks/1.0/facets.yaml
+++ b/modules/datastore/mysql/kubeblocks/1.0/facets.yaml
@@ -132,6 +132,7 @@ spec:
       description: Persistent storage settings for MySQL data
       x-ui-order:
       - size
+      - storage_class
       properties:
         size:
           type: string
@@ -139,6 +140,12 @@ spec:
           description: Size of persistent volume (can be expanded later, cannot be
             reduced)
           default: 20Gi
+        storage_class:
+          type: string
+          title: Storage Class
+          description: (Optional) Kubernetes StorageClass name for the persistent
+            volume. Leave empty to use the cluster's default StorageClass.
+          default: ''
       required:
       - size
     high_availability:

--- a/modules/datastore/mysql/kubeblocks/1.0/locals.tf
+++ b/modules/datastore/mysql/kubeblocks/1.0/locals.tf
@@ -17,7 +17,7 @@ locals {
   # PDB settings - maxUnavailable=1 ensures only 1 pod disrupted at a time
   enable_pdb = lookup(local.ha_config, "enable_pdb", false) && local.ha_enabled
 
-  create_read_service = true # Always create read service for replication mode
+  create_read_service = local.ha_enabled # Only create read service in replication (HA) mode
 
   # Get node pool details from input
   node_pool_input  = lookup(var.inputs, "node_pool", {})
@@ -52,13 +52,12 @@ locals {
   backup_method = "volume-snapshot"
 
   # Restore configuration - annotation-based restore from backup
-  restore_config  = lookup(var.instance.spec, "restore", {})
-  restore_enabled = lookup(local.restore_config, "enabled", false) == true
+  restore_enabled = try(var.instance.spec.restore.enabled, false) == true
 
   # Restore source details
   # Backup naming pattern from KubeBlocks:
   # - Volume-snapshot backups: {cluster-name}-backup-{timestamp}
-  restore_backup_name = lookup(local.restore_config, "backup_name", "")
+  restore_backup_name = try(var.instance.spec.restore.backup_name, "")
 
   # Component definition
   mysql_version = var.instance.spec.mysql_version

--- a/modules/datastore/mysql/kubeblocks/1.0/main.tf
+++ b/modules/datastore/mysql/kubeblocks/1.0/main.tf
@@ -94,9 +94,9 @@ module "mysql_cluster" {
                         }
                       }
                     },
-                    {
+                    var.instance.spec.storage.storage_class != "" ? {
                       storageClassName = var.instance.spec.storage.storage_class
-                    }
+                    } : {}
                   )
                 }
               ]
@@ -274,8 +274,6 @@ data "kubernetes_secret" "mysql_credentials" {
     name      = try(data.kubernetes_resources.mysql_secrets.objects[0].metadata.name, "${local.cluster_name}-mysql-account-root")
     namespace = local.namespace
   }
-
-  depends_on = [data.kubernetes_resources.mysql_secrets]
 }
 
 # Data Source: Primary Service

--- a/modules/datastore/mysql/kubeblocks/1.0/variables.tf
+++ b/modules/datastore/mysql/kubeblocks/1.0/variables.tf
@@ -18,7 +18,7 @@ variable "instance" {
   description = "MySQL cluster instance configuration"
   type = object({
     spec = object({
-      namespace_override = optional(string)
+      namespace_override = optional(string, "")
       termination_policy = string
       mysql_version      = string
       mode               = string
@@ -52,9 +52,9 @@ variable "instance" {
       }))
 
       restore = optional(object({
-        enabled     = optional(bool)
-        backup_name = optional(string)
-      }))
+        enabled     = optional(bool, false)
+        backup_name = optional(string, "")
+      }), { enabled = false, backup_name = "" })
     })
   })
 
@@ -94,12 +94,11 @@ variable "inputs" {
         chart_version = optional(string)
         release_id    = optional(string)
       }))
+      interfaces = optional(object({}), {})
     })
     kubernetes_cluster = object({
-      attributes = optional(object({
-        cluster_name = optional(string)
-        region       = optional(string)
-      }))
+      cluster_name = optional(string)
+      region       = optional(string)
     })
     node_pool = optional(object({
       attributes = object({
@@ -116,7 +115,7 @@ variable "inputs" {
         # Node labels used as nodeSelector
         node_selector = optional(map(string), {})
       })
-      interfaces = any
+      interfaces = optional(object({}), {})
     }))
   })
 }

--- a/modules/datastore/postgres/kubeblocks/1.0/facets.yaml
+++ b/modules/datastore/postgres/kubeblocks/1.0/facets.yaml
@@ -133,6 +133,7 @@ spec:
       description: Persistent storage settings for PostgreSQL data
       x-ui-order:
       - size
+      - storage_class
       properties:
         size:
           type: string
@@ -140,6 +141,12 @@ spec:
           description: Size of persistent volume (can be expanded later, cannot be
             reduced)
           default: 20Gi
+        storage_class:
+          type: string
+          title: Storage Class
+          description: (Optional) Kubernetes StorageClass name for the persistent
+            volume. Leave empty to use the cluster's default StorageClass.
+          default: ''
       required:
       - size
     high_availability:

--- a/modules/datastore/postgres/kubeblocks/1.0/locals.tf
+++ b/modules/datastore/postgres/kubeblocks/1.0/locals.tf
@@ -17,7 +17,7 @@ locals {
   # PDB settings - maxUnavailable=1 ensures only 1 pod disrupted at a time
   enable_pdb = lookup(local.ha_config, "enable_pdb", false) && local.ha_enabled
 
-  create_read_service = true # Always create read service for replication mode
+  create_read_service = local.ha_enabled # Only create read service in replication (HA) mode
 
   # Get node pool details from input
   node_pool_input  = lookup(var.inputs, "node_pool", {})
@@ -52,13 +52,12 @@ locals {
   backup_method = "volume-snapshot"
 
   # Restore configuration - annotation-based restore from backup
-  restore_config  = lookup(var.instance.spec, "restore", {})
-  restore_enabled = lookup(local.restore_config, "enabled", false) == true
+  restore_enabled = try(var.instance.spec.restore.enabled, false) == true
 
   # Restore source details
   # Backup naming pattern from KubeBlocks:
   # - Volume-snapshot backups: {cluster-name}-backup-{timestamp}
-  restore_backup_name = lookup(local.restore_config, "backup_name", "")
+  restore_backup_name = try(var.instance.spec.restore.backup_name, "")
 
   # Component definition
   postgres_version = var.instance.spec.postgres_version

--- a/modules/datastore/postgres/kubeblocks/1.0/main.tf
+++ b/modules/datastore/postgres/kubeblocks/1.0/main.tf
@@ -95,9 +95,9 @@ module "postgresql_cluster" {
                         }
                       }
                     },
-                    {
+                    var.instance.spec.storage.storage_class != "" ? {
                       storageClassName = var.instance.spec.storage.storage_class
-                    }
+                    } : {}
                   )
                 }
               ]
@@ -279,8 +279,6 @@ data "kubernetes_secret" "postgres_credentials" {
     name      = try(data.kubernetes_resources.postgres_secrets.objects[0].metadata.name, "${local.cluster_name}-postgresql-account-postgres")
     namespace = local.namespace
   }
-
-  depends_on = [data.kubernetes_resources.postgres_secrets]
 }
 
 # Data Source: Primary Service

--- a/modules/datastore/postgres/kubeblocks/1.0/outputs.tf
+++ b/modules/datastore/postgres/kubeblocks/1.0/outputs.tf
@@ -3,7 +3,7 @@ locals {
   output_interfaces = {
     writer = {
       host              = local.writer_host
-      port              = local.writer_port
+      port              = tostring(local.writer_port)
       username          = local.postgres_username
       password          = local.postgres_password
       database          = local.postgres_database
@@ -12,7 +12,7 @@ locals {
     }
     reader = local.create_read_service ? {
       host              = local.reader_host
-      port              = local.reader_port
+      port              = tostring(local.reader_port)
       username          = local.postgres_username
       password          = local.postgres_password
       database          = local.postgres_database
@@ -20,7 +20,7 @@ locals {
       secrets           = ["password", "connection_string"]
       } : {
       host              = local.writer_host
-      port              = local.writer_port
+      port              = tostring(local.writer_port)
       username          = local.postgres_username
       password          = local.postgres_password
       database          = local.postgres_database

--- a/modules/datastore/postgres/kubeblocks/1.0/variables.tf
+++ b/modules/datastore/postgres/kubeblocks/1.0/variables.tf
@@ -18,7 +18,7 @@ variable "instance" {
   description = "PostgreSQL cluster instance configuration"
   type = object({
     spec = object({
-      namespace_override = optional(string)
+      namespace_override = optional(string, "")
       termination_policy = string
       postgres_version   = string
       mode               = string
@@ -51,9 +51,9 @@ variable "instance" {
         backup_method    = optional(string)
       }))
       restore = optional(object({
-        enabled     = optional(bool)
-        backup_name = optional(string)
-      }))
+        enabled     = optional(bool, false)
+        backup_name = optional(string, "")
+      }), { enabled = false, backup_name = "" })
     })
   })
 }
@@ -68,12 +68,11 @@ variable "inputs" {
         chart_version = optional(string)
         release_id    = optional(string)
       }))
+      interfaces = optional(object({}), {})
     })
     kubernetes_cluster = object({
-      attributes = optional(object({
-        cluster_name = optional(string)
-        region       = optional(string)
-      }))
+      cluster_name = optional(string)
+      region       = optional(string)
     })
     node_pool = optional(object({
       attributes = object({
@@ -90,7 +89,7 @@ variable "inputs" {
         # Node labels used as nodeSelector
         node_selector = optional(map(string), {})
       })
-      interfaces = any
+      interfaces = optional(object({}), {})
     }))
   })
 }

--- a/outputs/mongo/outputs.yaml
+++ b/outputs/mongo/outputs.yaml
@@ -61,4 +61,6 @@ properties:
                 type: string
             username:
               type: string
+      additionalProperties:
+        type: object
 providers: []

--- a/outputs/mongo_k8s/outputs.yaml
+++ b/outputs/mongo_k8s/outputs.yaml
@@ -6,8 +6,7 @@ properties:
       type: object
       properties:
         external_endpoints:
-          type: object
-          properties: {}
+          type: string
     interfaces:
       type: object
       properties: {}

--- a/outputs/postgres/outputs.yaml
+++ b/outputs/postgres/outputs.yaml
@@ -12,6 +12,8 @@ properties:
           properties:
             connection_string:
               type: string
+            database:
+              type: string
             host:
               type: string
             password:
@@ -28,6 +30,8 @@ properties:
           type: object
           properties:
             connection_string:
+              type: string
+            database:
               type: string
             host:
               type: string


### PR DESCRIPTION
## Summary
Four commits, one per module, all in the KubeBlocks family (mongo/postgres/mysql datastore modules + the shared kubeblocks-operator):

- **`mongo/kubeblocks`**: `restore` optional-object null-crash (RULE-015) + RULE-006/012/017/025 output-wiring and schema fixes + missing `storage_class` schema field. Version `1.1`→`1.2`.
- **`postgres/kubeblocks`**: same `restore` null-crash, **plus a real bug** — `create_read_service` was hardcoded `true`, so standalone (non-HA) deploys handed out a `reader` endpoint pointing at a Service with zero backing pods. Fixed to follow `local.ha_enabled`. Same RULE-006/012/017/025 fixes as mongo.
- **`mysql/kubeblocks`**: same `restore` null-crash and same `create_read_service` bug as postgres, plus the same RULE-006/017/025 fixes (mysql's output types were already correct, so no RULE-012 fix needed here).
- **`kubeblocks-operator`**: `resources` optional-object null-crash (RULE-015, reproduced locally via `terraform apply` before fixing), **plus a real bug** — `spec.database_addons` was supposed to toggle which addon Helm charts install but was never actually wired up; all five installed unconditionally regardless of the setting, and an unrelated redis/kafka chart failure could block the whole operator apply. Fixed by filtering `enabled_addons` against the spec (defaulting to `true`, so no behavior change for existing deployments that don't set it). Also swapped a stray `bitnamilegacy/kubectl` image for the canonical `registry.k8s.io/kubectl` tag.

## Test plan
- [x] `raptor create iac-module --dry-run` passes clean on all four modules
- [x] `terraform fmt` / `terraform validate` clean on all four (only pre-existing, unrelated deprecation warnings)
- [x] Traced the `create_read_service` fix through both standalone and replication branches of the output ternary on postgres and mysql
- [x] Reproduced the `kubeblocks-operator` `resources` null-crash locally via `terraform apply` before fixing, confirmed the fix resolves it