### PR TITLE
fix(kubernetes_cluster): pin latest GA k8s versions; configurable GKE maintenance window

### DIFF
--- a/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_standard/1.0/facets.yaml
@@ -247,7 +247,6 @@ spec:
                 - "1.34"
                 - "1.35"
                 - "1.36"
-                - "1.37"
             title: Kubernetes Version
             type: string
             x-ui-overrides-only: true

--- a/modules/kubernetes_cluster/eks_standard/1.0/variables.tf
+++ b/modules/kubernetes_cluster/eks_standard/1.0/variables.tf
@@ -48,8 +48,8 @@ variable "instance" {
   })
 
   validation {
-    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36", "1.37"], var.instance.spec.cluster_version)
-    error_message = "Kubernetes version must be one of: 1.28, 1.29, 1.30, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36, 1.37"
+    condition     = contains(["1.28", "1.29", "1.30", "1.31", "1.32", "1.33", "1.34", "1.35", "1.36"], var.instance.spec.cluster_version)
+    error_message = "Kubernetes version must be one of: 1.28, 1.29, 1.30, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36"
   }
 
   validation {

--- a/modules/kubernetes_cluster/gke/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/gke/1.0/facets.yaml
@@ -19,6 +19,17 @@ spec:
       title: Enable Auto-Upgrade
       description: Enable automatic cluster upgrades via release channel
       default: true
+    maintenance_window:
+      type: object
+      title: Maintenance Window
+      description: Daily maintenance window for automatic control-plane upgrades (UTC). Only applies when auto-upgrade is enabled.
+      properties:
+        start_time:
+          type: string
+          title: Start Time (UTC)
+          description: Daily maintenance window start time in HH:MM (UTC). GKE runs a 4-hour daily window starting at this time.
+          default: "03:00"
+          pattern: ^([01][0-9]|2[0-3]):[0-5][0-9]$
     whitelisted_cidrs:
       type: array
       title: Whitelisted CIDRs
@@ -122,6 +133,8 @@ sample:
   version: '1.0'
   spec:
     auto_upgrade: true
+    maintenance_window:
+      start_time: "03:00"
     whitelisted_cidrs:
     - 0.0.0.0/0
     logging_components:

--- a/modules/kubernetes_cluster/gke/1.0/locals.tf
+++ b/modules/kubernetes_cluster/gke/1.0/locals.tf
@@ -6,6 +6,9 @@ locals {
   auto_upgrade    = lookup(local.spec, "auto_upgrade", true)
   release_channel = local.auto_upgrade ? "STABLE" : "UNSPECIFIED" # Hardcoded to STABLE
 
+  # Daily maintenance window start time (UTC), configurable; defaults to 03:00
+  maintenance_start_time = lookup(lookup(local.spec, "maintenance_window", {}), "start_time", "03:00")
+
   # Network configuration from VPC module
   network_attributes = lookup(var.inputs.network_details, "attributes", {})
   project_id         = lookup(var.inputs.cloud_account, "attributes", {}).project_id

--- a/modules/kubernetes_cluster/gke/1.0/main.tf
+++ b/modules/kubernetes_cluster/gke/1.0/main.tf
@@ -114,12 +114,12 @@ resource "google_container_cluster" "primary" {
   }
 
   # Maintenance policy - only when auto-upgrade is enabled
-  # Daily maintenance window at 3 AM UTC for 4 hours
+  # Daily maintenance window (UTC, 4-hour window); start time configurable via spec.maintenance_window.start_time
   dynamic "maintenance_policy" {
     for_each = local.auto_upgrade ? [1] : []
     content {
       daily_maintenance_window {
-        start_time = "03:00"
+        start_time = local.maintenance_start_time
       }
     }
   }

--- a/modules/kubernetes_cluster/vke/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/vke/1.0/facets.yaml
@@ -22,9 +22,9 @@ spec:
     k8s_version:
       type: string
       title: Kubernetes Version
-      description: "VKE Kubernetes version, including the build suffix (e.g. v1.35.0+1). Vultr version strings are volatile; list current values with the Vultr API (GET /v2/kubernetes/versions)."
-      default: "v1.35.0+1"
-      x-ui-placeholder: "v1.35.0+1"
+      description: "VKE Kubernetes version, including the build suffix (e.g. v1.36.1+2). Vultr version strings are volatile; list current values with the Vultr API (GET /v2/kubernetes/versions)."
+      default: "v1.36.1+2"
+      x-ui-placeholder: "v1.36.1+2"
       pattern: ^v[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$
     high_availability:
       type: boolean
@@ -144,7 +144,7 @@ sample:
   version: "1.0"
   disabled: true
   spec:
-    k8s_version: "v1.35.0+1"
+    k8s_version: "v1.36.1+2"
     high_availability: false
     enable_firewall: false
     default_pool:

--- a/modules/kubernetes_cluster/vke/1.0/variables.tf
+++ b/modules/kubernetes_cluster/vke/1.0/variables.tf
@@ -22,7 +22,7 @@ variable "instance" {
 
   validation {
     condition     = can(regex("^v[0-9]+\\.[0-9]+\\.[0-9]+\\+[0-9]+$", var.instance.spec.k8s_version))
-    error_message = "k8s_version must be a Vultr VKE version string like v1.35.0+1."
+    error_message = "k8s_version must be a Vultr VKE version string like v1.36.1+2."
   }
 
   validation {


### PR DESCRIPTION
## Summary

Two threads of work on the `kubernetes_cluster` flavors.

### Task 1 — support latest k8s (pin to latest GA, not null)
Verified current GA versions live per provider (Jul 2026).

| Flavor | Latest GA | Before | Change |
|--------|-----------|--------|--------|
| **eks_standard** | `1.36` (standard support 1.33–1.36; **1.37 not on EKS**) | enum `1.28–1.37`, default `1.36` | Removed bogus `1.37` from enum + `variables.tf` validation. Default `1.36` unchanged. |
| **vke** | `v1.36.1+2` | default `v1.35.0+1` | Bumped default/placeholder/sample/validation msg → `v1.36.1+2`. |
| **lke** | `1.35` | default `1.35` | Already latest — no change. |

- EKS managed addons (vpc-cni, kube-proxy, coredns, ebs-csi, metrics-server, cloudwatch) all resolve via `null`/`"latest"` per cluster version, so they auto-match — no addon edits needed.

### Task 2 — auto cluster upgrades (GKE)
- **gke**: daily maintenance window start time is now configurable via `spec.maintenance_window.start_time` (default `"03:00"` → behavior unchanged). Release channel kept at `STABLE`. Node-pool auto-upgrade **intentionally not managed** — left to consumers to run on their own timeline.
- **aks**: left as-is (auto-upgrade already always-on, channel-selectable).

## Validation
- `raptor create iac-module --dry-run` — **pass** for `eks_standard` and `gke`.
- No control-plane changes / uploads. Modules not published.

## Not fixed here (pre-existing, out of scope)
- **vke** dry-run fails on this profile for two reasons unrelated to the version bump:
  1. `required_providers` (RULE-013) — **must stay**: `vultr` is a non-hashicorp provider (`vultr/vultr`); every vultr module in the repo declares it, and terraform can't resolve the source namespace without it. RULE-013 is a false-positive for non-hashicorp providers.
  2. `@facets/vultr_cloud_account` input type 404 — the type is defined in-repo (`outputs/vultr_cloud_account/`) but not registered on the test CP profile. CP-registration matter, not a code bug.
- **gke** `variable "instance"` is `type = any` (RULE-025) — pre-existing; full retype is its own task.

## Version bumps
None required (RULE-023): EKS change removes an invalid option (bugfix), VKE is a default change, GKE adds an optional field — all non-breaking.