### PR TITLE
artifactories: set ecr-token-refresher image to facetscloud/aws-kubectl:1.7.0

### DIFF
--- a/modules/common/artifactories/standard/1.0/ecr-token-refresher.tf
+++ b/modules/common/artifactories/standard/1.0/ecr-token-refresher.tf
@@ -70,7 +70,7 @@ resource "kubernetes_cron_job_v1" "ecr-token-refresher-cron" {
             priority_class_name             = kubernetes_priority_class_v1.ecr_token_refresher.metadata[0].name
             container {
               name              = "kubectl"
-              image             = "xynova/aws-kubectl"
+              image             = "facetscloud/aws-kubectl:1.7.0"
               image_pull_policy = "Always"
               command           = ["/bin/sh", "-c", file("${path.module}/ecr-token-refresher-command")]
               env {
@@ -225,7 +225,7 @@ resource "kubernetes_job_v1" "ecr-token-refresher-initial" {
         priority_class_name             = kubernetes_priority_class_v1.ecr_token_refresher.metadata[0].name
         container {
           name              = "kubectl"
-          image             = "xynova/aws-kubectl"
+          image             = "facetscloud/aws-kubectl:1.7.0"
           image_pull_policy = "Always"
           command           = ["/bin/sh", "-c", file("${path.module}/ecr-token-refresher-command")]
           env {


### PR DESCRIPTION
Replaces the removed `xynova/aws-kubectl` with **`facetscloud/aws-kubectl:1.7.0`** on both ecr-token-refresher cronjob container references in `modules/common/artifactories/standard/1.0/ecr-token-refresher.tf` (lines 73, 228).

`:1.7.0` is the self-hosted rebuild matching the original xynova gist (kubectl v1.7.0), published to Docker Hub.

Note: kubectl v1.7.0 is a 2017 binary — validate on a real amd64 node before rollout (a local panic seen was under QEMU arm64-emulation, likely an emulation artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)