### PR TITLE
fix(nginx_gateway_fabric_aws): auto-issue ACM cert for base domain in acm_mode

### DIFF
--- a/modules/ingress/nginx_gateway_fabric_aws/1.0/main.tf
+++ b/modules/ingress/nginx_gateway_fabric_aws/1.0/main.tf
@@ -1,6 +1,40 @@
+# Control-plane metadata (tenant provider + base domain) — read the same way as the
+# base module. Computed here in the wrapper so base_domain can be derived WITHOUT
+# depending on the base module's outputs (that would create a cycle: base_domain →
+# ssl-cert annotation → base module input).
+data "external" "cc_env" {
+  program = ["sh", "-c", <<-EOT
+    echo "{\"cc_tenant_provider\":\"$TF_VAR_cc_tenant_provider\",\"tenant_base_domain\":\"$TF_VAR_tenant_base_domain\"}"
+  EOT
+  ]
+}
+
+# Route53 zone for the tenant base domain (AWS only) — target zone for the base
+# domain ACM certificate's DNS validation records. Lives in the tooling account.
+data "aws_route53_zone" "base_domain_zone" {
+  count    = local.tenant_provider == "aws" ? 1 : 0
+  name     = local.tenant_base_domain
+  provider = aws3tooling
+}
+
 locals {
   # Compute name the same way as the base module (needed for ACM secret names)
   name = lower(var.environment.namespace == "default" ? var.instance_name : "${var.environment.namespace}-${var.instance_name}")
+
+  # Control-plane metadata (same derivation as the base module)
+  cc_tenant_provider    = data.external.cc_env.result.cc_tenant_provider
+  tenant_base_domain    = data.external.cc_env.result.tenant_base_domain
+  tenant_provider       = lower(local.cc_tenant_provider != "" ? local.cc_tenant_provider : "aws")
+  tenant_base_domain_id = length(data.aws_route53_zone.base_domain_zone) > 0 ? data.aws_route53_zone.base_domain_zone[0].zone_id : ""
+
+  # Base domain — MUST stay byte-for-byte in sync with the base module's
+  # computation (facets-utility-modules//nginx_gateway_fabric: instance_env_name /
+  # check_domain_prefix / base_domain). A mismatch would issue the base ACM cert
+  # for the wrong host.
+  instance_env_name   = length(var.environment.unique_name) + length(var.instance_name) + length(local.tenant_base_domain) >= 60 ? substr(md5("${var.instance_name}-${var.environment.unique_name}"), 0, 20) : "${var.instance_name}-${var.environment.unique_name}"
+  check_domain_prefix = coalesce(lookup(var.instance.spec, "domain_prefix_override", null), local.instance_env_name)
+  base_domain         = lower("${local.check_domain_prefix}.${local.tenant_base_domain}")
+  base_subdomain      = "*.${local.base_domain}"
 
   # Detect domains with ACM ARN as certificate_reference
   acm_cert_domains = {
@@ -22,10 +56,21 @@ locals {
   # TLS terminates at the NLB instead of at the Gateway pod
   acm_mode = !local.use_ack_acm && length(local.acm_cert_domains) > 0
 
-  # ACM ARNs to attach to NLB for TLS termination
-  acm_cert_arns = local.acm_mode ? distinct([
-    for domain_key, domain in local.acm_cert_domains : domain.certificate_reference
-  ]) : []
+  # Auto-issue an ACM cert for the base domain whenever TLS terminates at the NLB
+  # (acm_mode) and the base domain is active on AWS. The base domain carries no
+  # certificate_reference, so without this it would contribute no ARN to the
+  # ssl-cert annotation → base-domain HTTPS falls back to the NLB default cert and
+  # fails hostname validation. When acm_mode is false, the base domain keeps using
+  # cert-manager (unchanged), so no base ACM cert is needed.
+  base_acm_enabled = local.acm_mode && !lookup(var.instance.spec, "disable_base_domain", false) && local.tenant_provider == "aws"
+
+  # ACM ARNs to attach to NLB for TLS termination — user-supplied ARNs plus the
+  # auto-issued base-domain cert (validated ARN, so the NLB never attaches an
+  # unvalidated certificate).
+  acm_cert_arns = local.acm_mode ? distinct(concat(
+    [for domain_key, domain in local.acm_cert_domains : domain.certificate_reference],
+    local.base_acm_enabled ? [aws_acm_certificate_validation.base_acm[0].certificate_arn] : []
+  )) : []
 
   # Rewrite ACM ARN certificate_reference → K8s secret name for all ACM domains.
   # In ACM mode (no ACK), this rewrite is harmless — external_tls_termination=true
@@ -156,4 +201,58 @@ resource "kubernetes_secret_v1" "acm_cert" {
   lifecycle {
     ignore_changes = [data, metadata[0].annotations, metadata[0].labels]
   }
+}
+
+# --- Auto-issued base-domain ACM certificate ---
+# Issued when TLS terminates at the NLB (acm_mode) and the base domain is active.
+# Covers base_domain + *.base_domain; its validated ARN is appended to the NLB
+# ssl-cert annotation via local.acm_cert_arns, so the base domain always has a
+# matching certificate without relying on cert-manager.
+#
+# Provider split (cross-account): the certificate is issued in the DEFAULT aws
+# provider (workload account + region, where the NLB lives — an ACM cert attached
+# to an NLB must be in the same account/region), while its DNS validation records
+# are written to the tooling account's Route53 zone via aws3tooling.
+resource "aws_acm_certificate" "base_acm" {
+  count                     = local.base_acm_enabled ? 1 : 0
+  domain_name               = local.base_domain
+  subject_alternative_names = [local.base_subdomain]
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [options]
+  }
+}
+
+resource "aws_route53_record" "base_acm_validation" {
+  # Key by the domain names we requested (known at plan time). Keying off
+  # domain_validation_options fails for a brand-new cert — ACM computes the whole
+  # set at apply, so for_each can't resolve its keys. Record values are looked up
+  # per key from the computed set (may be unknown at plan — that's fine). ACM can
+  # emit the same CNAME for apex + wildcard; allow_overwrite handles the duplicate.
+  for_each = local.base_acm_enabled ? toset([local.base_domain, local.base_subdomain]) : toset([])
+
+  allow_overwrite = true
+  name = one([
+    for d in aws_acm_certificate.base_acm[0].domain_validation_options :
+    d.resource_record_name if d.domain_name == each.key
+  ])
+  records = [one([
+    for d in aws_acm_certificate.base_acm[0].domain_validation_options :
+    d.resource_record_value if d.domain_name == each.key
+  ])]
+  type = one([
+    for d in aws_acm_certificate.base_acm[0].domain_validation_options :
+    d.resource_record_type if d.domain_name == each.key
+  ])
+  ttl      = 60
+  zone_id  = local.tenant_base_domain_id
+  provider = aws3tooling
+}
+
+resource "aws_acm_certificate_validation" "base_acm" {
+  count                   = local.base_acm_enabled ? 1 : 0
+  certificate_arn         = aws_acm_certificate.base_acm[0].arn
+  validation_record_fqdns = [for r in aws_route53_record.base_acm_validation : r.fqdn]
 }


### PR DESCRIPTION
## Problem

In **acm_mode** — an ACM ARN is supplied as a domain's `certificate_reference` and no ACK ACM controller is present — TLS terminates at the NLB and the wrapper sets `external_tls_termination=true`, which disables cert-manager in the base module.

The **base domain** carries no `certificate_reference`, so it contributed **no ARN** to the `service.beta.kubernetes.io/aws-load-balancer-ssl-cert` annotation. Result: base-domain HTTPS fell back to the NLB **default** certificate (first ARN in the list) and failed hostname validation unless a user-supplied ACM cert coincidentally SAN'd the base domain.

Two independent code paths caused it:
- `certmanager_managed_domains = var.external_tls_termination ? {} : {...}` (base module) → cert-manager issues nothing in acm_mode.
- The wrapper's `acm_cert_arns` only scanned `spec.domains` (user overrides). The base domain is injected *inside* the base module, so the wrapper never saw it.

## Fix

Port the base-domain ACM handling from the **capillary** flavour (`Facets-cloud/ingress-migration@init/nginx_gateway_fabric_capillary`). When `acm_mode` is active and the base domain is enabled on AWS:

1. Issue an ACM certificate covering `base_domain` + `*.base_domain` (DNS validation).
2. Publish its validation records to the tooling-account Route53 zone.
3. Append the **validated** ARN to `local.acm_cert_arns` → always lands in the `ssl-cert` annotation.

`base_domain` is derived in the wrapper from the same control-plane metadata the base module uses (`data.external.cc_env`), **not** the base module's output — this avoids a dependency cycle (`base_domain` → ssl-cert annotation → base module input).

### Provider split (cross-account) — reviewer note
Matches capillary:
- `aws_acm_certificate` / `aws_acm_certificate_validation` → **default `aws` provider** (workload account + region; an ACM cert attached to an NLB must be in the same account/region as the NLB).
- `aws_route53_record` (DNS validation) + `data.aws_route53_zone` → **`aws3tooling`** (tooling-account Route53 zone).

Both providers are injected at deploy time by the iac-generator (same as `nginx_k8s` and the base module) — no `required_providers` in module source, per repo convention (`facets_default_providers`).

## Guards
- Fires only when `acm_mode == true`, `disable_base_domain != true`, and `tenant_provider == "aws"`.
- When `acm_mode` is false, the base domain keeps using cert-manager (unchanged).
- `disable_base_domain = true` → zero base-ACM resources.

## Validation
- `terraform fmt` clean.
- `raptor ... --dry-run` `terraform init` fails on `aws3tooling` — **pre-existing** and inherent to deploy-time provider injection; the **pristine** module fails identically (verified). Real validation happens on CP upload where providers are injected.

⚠️ **Not yet applied against the Control Plane.** Needs a real plan/apply in a sandbox to confirm: base-ACM cert issued, `ssl-cert` annotation shows ≥2 ARNs incl. base, and `curl https://<base_domain>` returns a valid cert.

## Follow-up / maintenance note
`base_domain` derivation is now duplicated in the wrapper and the base module and **must stay byte-for-byte in sync** (flagged in a code comment). Worth considering a shared source later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)