### PR TITLE
fix(kubernetes_cluster): race-safe exec provider for authenticator install

### DIFF
--- a/modules/kubernetes_cluster/eks_automode/1.0/outputs.tf
+++ b/modules/kubernetes_cluster/eks_automode/1.0/outputs.tf
@@ -1,4 +1,18 @@
 locals {
+  # EKS token exec for the kubernetes/helm/kubectl providers. The runner image
+  # may lack aws-iam-authenticator, so the command self-installs it — but all
+  # providers exec this script CONCURRENTLY at plan start, so the install must
+  # be race-safe: flock serializes to a single download (double-checked inside
+  # the lock), the download lands in a per-process mktemp file INSIDE
+  # /usr/local/bin (same filesystem), and mv -f is then an atomic rename — a
+  # concurrent exec sees either no binary or a complete one, never a partial
+  # write (a shared /tmp path corrupted under concurrency: exit 126).
+  kubernetes_provider_exec = {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "bash"
+    args        = ["-c", "command -v aws-iam-authenticator >/dev/null 2>&1 || flock /usr/local/bin/.aws-iam-authenticator.lock bash -c 'command -v aws-iam-authenticator >/dev/null 2>&1 && exit 0; t=$(mktemp /usr/local/bin/.aws-iam-authenticator.XXXXXX) && curl -fsSLo $t https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.8/aws-iam-authenticator_0.7.8_linux_amd64 && chmod +x $t && mv -f $t /usr/local/bin/aws-iam-authenticator'; aws-iam-authenticator token -i ${module.eks.cluster_name} --role ${var.inputs.cloud_account.attributes.aws_iam_role} -s facets-k8s-${var.instance_name} -e ${var.inputs.cloud_account.attributes.external_id} --region ${var.inputs.cloud_account.attributes.aws_region}"]
+  }
+  # tflint-ignore: terraform_unused_declarations
   output_attributes = {
     cluster_endpoint       = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
@@ -14,23 +28,16 @@ locals {
     node_iam_role_name     = module.eks.node_iam_role_name
     node_security_group_id = module.eks.node_security_group_id
     cloud_provider         = "AWS"
-    kubernetes_provider_exec = {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "bash"
-      args        = ["-c", "command -v aws-iam-authenticator >/dev/null 2>&1 || (curl -sLo /tmp/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.8/aws-iam-authenticator_0.7.8_linux_amd64 && chmod +x /tmp/aws-iam-authenticator && mv /tmp/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator); aws-iam-authenticator token -i ${module.eks.cluster_name} --role ${var.inputs.cloud_account.attributes.aws_iam_role} -s facets-k8s-${var.instance_name} -e ${var.inputs.cloud_account.attributes.external_id} --region ${var.inputs.cloud_account.attributes.aws_region}"]
-    }
-    secrets = ["cluster_ca_certificate", "kubernetes_provider_exec"]
+    kubernetes_provider_exec = local.kubernetes_provider_exec
+    secrets                  = ["cluster_ca_certificate", "kubernetes_provider_exec"]
   }
+  # tflint-ignore: terraform_unused_declarations
   output_interfaces = {
     kubernetes = {
-      host                   = module.eks.cluster_endpoint
-      cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-      kubernetes_provider_exec = {
-        api_version = "client.authentication.k8s.io/v1beta1"
-        command     = "bash"
-        args        = ["-c", "command -v aws-iam-authenticator >/dev/null 2>&1 || (curl -sLo /tmp/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.8/aws-iam-authenticator_0.7.8_linux_amd64 && chmod +x /tmp/aws-iam-authenticator && mv /tmp/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator); aws-iam-authenticator token -i ${module.eks.cluster_name} --role ${var.inputs.cloud_account.attributes.aws_iam_role} -s facets-k8s-${var.instance_name} -e ${var.inputs.cloud_account.attributes.external_id} --region ${var.inputs.cloud_account.attributes.aws_region}"]
-      }
-      secrets = ["cluster_ca_certificate", "kubernetes_provider_exec"]
+      host                     = module.eks.cluster_endpoint
+      cluster_ca_certificate   = base64decode(module.eks.cluster_certificate_authority_data)
+      kubernetes_provider_exec = local.kubernetes_provider_exec
+      secrets                  = ["cluster_ca_certificate", "kubernetes_provider_exec"]
     }
   }
 }

--- a/modules/kubernetes_cluster/eks_standard/1.0/outputs.tf
+++ b/modules/kubernetes_cluster/eks_standard/1.0/outputs.tf
@@ -1,4 +1,18 @@
 locals {
+  # EKS token exec for the kubernetes/helm/kubectl providers. The runner image
+  # may lack aws-iam-authenticator, so the command self-installs it — but all
+  # providers exec this script CONCURRENTLY at plan start, so the install must
+  # be race-safe: flock serializes to a single download (double-checked inside
+  # the lock), the download lands in a per-process mktemp file INSIDE
+  # /usr/local/bin (same filesystem), and mv -f is then an atomic rename — a
+  # concurrent exec sees either no binary or a complete one, never a partial
+  # write (a shared /tmp path corrupted under concurrency: exit 126).
+  kubernetes_provider_exec = {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "bash"
+    args        = ["-c", "command -v aws-iam-authenticator >/dev/null 2>&1 || flock /usr/local/bin/.aws-iam-authenticator.lock bash -c 'command -v aws-iam-authenticator >/dev/null 2>&1 && exit 0; t=$(mktemp /usr/local/bin/.aws-iam-authenticator.XXXXXX) && curl -fsSLo $t https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.8/aws-iam-authenticator_0.7.8_linux_amd64 && chmod +x $t && mv -f $t /usr/local/bin/aws-iam-authenticator'; aws-iam-authenticator token -i ${module.eks.cluster_name} --role ${var.inputs.cloud_account.attributes.aws_iam_role} -s facets-k8s-${var.instance_name} -e ${var.inputs.cloud_account.attributes.external_id} --region ${var.inputs.cloud_account.attributes.aws_region}"]
+  }
+  # tflint-ignore: terraform_unused_declarations
   output_attributes = {
     cluster_endpoint                  = module.eks.cluster_endpoint
     cluster_ca_certificate            = base64decode(module.eks.cluster_certificate_authority_data)
@@ -17,23 +31,16 @@ locals {
     cluster_security_group_id         = module.eks.cluster_security_group_id
     cloud_provider                    = "AWS"
     cluster_location                  = var.inputs.cloud_account.attributes.aws_region
-    kubernetes_provider_exec = {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "bash"
-      args        = ["-c", "command -v aws-iam-authenticator >/dev/null 2>&1 || (curl -sLo /tmp/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.8/aws-iam-authenticator_0.7.8_linux_amd64 && chmod +x /tmp/aws-iam-authenticator && mv /tmp/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator); aws-iam-authenticator token -i ${module.eks.cluster_name} --role ${var.inputs.cloud_account.attributes.aws_iam_role} -s facets-k8s-${var.instance_name} -e ${var.inputs.cloud_account.attributes.external_id} --region ${var.inputs.cloud_account.attributes.aws_region}"]
-    }
-    secrets = ["cluster_ca_certificate", "kubernetes_provider_exec"]
+    kubernetes_provider_exec          = local.kubernetes_provider_exec
+    secrets                           = ["cluster_ca_certificate", "kubernetes_provider_exec"]
   }
+  # tflint-ignore: terraform_unused_declarations
   output_interfaces = {
     kubernetes = {
-      host                   = module.eks.cluster_endpoint
-      cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-      kubernetes_provider_exec = {
-        api_version = "client.authentication.k8s.io/v1beta1"
-        command     = "bash"
-        args        = ["-c", "command -v aws-iam-authenticator >/dev/null 2>&1 || (curl -sLo /tmp/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.8/aws-iam-authenticator_0.7.8_linux_amd64 && chmod +x /tmp/aws-iam-authenticator && mv /tmp/aws-iam-authenticator /usr/local/bin/aws-iam-authenticator); aws-iam-authenticator token -i ${module.eks.cluster_name} --role ${var.inputs.cloud_account.attributes.aws_iam_role} -s facets-k8s-${var.instance_name} -e ${var.inputs.cloud_account.attributes.external_id} --region ${var.inputs.cloud_account.attributes.aws_region}"]
-      }
-      secrets = ["cluster_ca_certificate", "kubernetes_provider_exec"]
+      host                     = module.eks.cluster_endpoint
+      cluster_ca_certificate   = base64decode(module.eks.cluster_certificate_authority_data)
+      kubernetes_provider_exec = local.kubernetes_provider_exec
+      secrets                  = ["cluster_ca_certificate", "kubernetes_provider_exec"]
     }
   }
 }

--- a/modules/kubernetes_cluster/gke/1.0/outputs.tf
+++ b/modules/kubernetes_cluster/gke/1.0/outputs.tf
@@ -1,4 +1,18 @@
 locals {
+  # GKE token exec for the kubernetes/helm/kubectl providers. The runner image
+  # may lack gke-auth-plugin, so the command self-installs it — but all
+  # providers exec this script CONCURRENTLY at plan start, so the install must
+  # be race-safe: flock serializes to a single download (double-checked inside
+  # the lock), the download lands in a per-process mktemp file INSIDE
+  # /usr/local/bin (same filesystem), and mv -f is then an atomic rename — a
+  # concurrent exec sees either no binary or a complete one, never a partial
+  # write (a shared /tmp path corrupted under concurrency: exit 126).
+  kubernetes_provider_exec = {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "bash"
+    args        = ["-c", "command -v gke-auth-plugin >/dev/null 2>&1 || flock /usr/local/bin/.gke-auth-plugin.lock bash -c 'command -v gke-auth-plugin >/dev/null 2>&1 && exit 0; t=$(mktemp /usr/local/bin/.gke-auth-plugin.XXXXXX) && curl -fsSLo $t.tar.gz https://github.com/traviswt/gke-auth-plugin/releases/download/0.3.0/gke-auth-plugin_Linux_x86_64.tar.gz && tar -xzf $t.tar.gz -C /tmp gke-auth-plugin && chmod +x /tmp/gke-auth-plugin && mv -f /tmp/gke-auth-plugin $t && rm -f $t.tar.gz && mv -f $t /usr/local/bin/gke-auth-plugin'; echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
+  }
+  # tflint-ignore: terraform_unused_declarations
   output_attributes = {
     # Cluster identification
     cluster_id       = google_container_cluster.primary.id
@@ -9,11 +23,7 @@ locals {
     # Authentication - standard names matching EKS/AKS
     cluster_endpoint       = "https://${google_container_cluster.primary.endpoint}"
     cluster_ca_certificate = base64decode(google_container_cluster.primary.master_auth[0].cluster_ca_certificate)
-    kubernetes_provider_exec = {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "bash"
-      args        = ["-c", "command -v gke-auth-plugin >/dev/null 2>&1 || (curl -sLo /tmp/gke-auth-plugin.tar.gz https://github.com/traviswt/gke-auth-plugin/releases/download/0.3.0/gke-auth-plugin_Linux_x86_64.tar.gz && tar -xzf /tmp/gke-auth-plugin.tar.gz -C /tmp && chmod +x /tmp/gke-auth-plugin && mv /tmp/gke-auth-plugin /usr/local/bin/gke-auth-plugin); echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
-    }
+    kubernetes_provider_exec = local.kubernetes_provider_exec
 
     # Project and region details
     project_id = local.project_id
@@ -44,16 +54,13 @@ locals {
     secrets = ["cluster_ca_certificate"]
   }
 
+  # tflint-ignore: terraform_unused_declarations
   output_interfaces = {
     kubernetes = {
-      host                   = "https://${google_container_cluster.primary.endpoint}"
-      cluster_ca_certificate = base64decode(google_container_cluster.primary.master_auth[0].cluster_ca_certificate)
-      kubernetes_provider_exec = {
-        api_version = "client.authentication.k8s.io/v1beta1"
-        command     = "bash"
-        args        = ["-c", "command -v gke-auth-plugin >/dev/null 2>&1 || (curl -sLo /tmp/gke-auth-plugin.tar.gz https://github.com/traviswt/gke-auth-plugin/releases/download/0.3.0/gke-auth-plugin_Linux_x86_64.tar.gz && tar -xzf /tmp/gke-auth-plugin.tar.gz -C /tmp && chmod +x /tmp/gke-auth-plugin && mv /tmp/gke-auth-plugin /usr/local/bin/gke-auth-plugin); echo '${local.credentials}' > /tmp/gcp-creds-$$.json && GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp-creds-$$.json gke-auth-plugin; rm -f /tmp/gcp-creds-$$.json"]
-      }
-      secrets = ["cluster_ca_certificate"]
+      host                     = "https://${google_container_cluster.primary.endpoint}"
+      cluster_ca_certificate   = base64decode(google_container_cluster.primary.master_auth[0].cluster_ca_certificate)
+      kubernetes_provider_exec = local.kubernetes_provider_exec
+      secrets                  = ["cluster_ca_certificate"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- **eks_standard/1.0**, **eks_automode/1.0**, **gke/1.0**: Replace non-race-safe authenticator install (direct `/tmp` download) with flock-serialized, atomic-rename pattern
- Extracts `kubernetes_provider_exec` into a dedicated `local` so both `output_attributes` and `output_interfaces` reference a single definition
- Prevents `exit 126` (partial binary write) when multiple Terraform providers exec the install script concurrently at plan start

## Problem
All providers (kubernetes, helm, kubectl) exec the authenticator install script **concurrently** at plan start. The old approach:
1. Downloaded to a shared `/tmp/aws-iam-authenticator` path
2. Had no locking — concurrent downloads corrupted the binary
3. Resulted in `exit 126` (cannot execute binary file)

**Error:**
```
Error: Get "https://4924E44147D54FA4CDFF4E71411664B9.yl4.ap-southeast-1.eks.amazonaws.com/api/v1/namespaces/default/secrets/mongo-user-mongo-ro-user": getting credentials: exec: executable bash failed with exit code 126
```

## Fix
- `flock` serializes the install to one process at a time
- Double-check inside the lock avoids redundant downloads
- `mktemp` inside `/usr/local/bin` + `mv -f` = atomic rename (same filesystem)
- A concurrent exec sees either no binary or a complete one, never a partial write

## Test plan
- [ ] Verify `raptor create iac-module --dry-run` passes for all three modules
- [ ] Confirm concurrent provider exec no longer causes exit 126

🤖 Generated with [Claude Code](https://claude.com/claude-code)