### PR TITLE
 fix(spec): use type: integer for whole-number spec fields across 26 modules

### DIFF
--- a/modules/common/aws_api_gateway/standard/1.0/facets.yaml
+++ b/modules/common/aws_api_gateway/standard/1.0/facets.yaml
@@ -294,7 +294,7 @@ spec:
             type: string
           default: []
         max_age:
-          type: number
+          type: integer
           title: Max Age (seconds)
           description: How long preflight response can be cached
 
@@ -374,7 +374,7 @@ spec:
           x-ui-visible-if:
             field: spec.stage_access_log_settings.create_log_group
         log_group_retention_in_days:
-          type: number
+          type: integer
           title: Log Retention (days)
           description: Number of days to retain access logs in CloudWatch
           default: 7
@@ -439,7 +439,7 @@ spec:
             - ERROR
             - INFO
         throttling_burst_limit:
-          type: number
+          type: integer
           title: Throttling Burst Limit
           description: Throttling burst limit for all routes
           default: 100
@@ -499,7 +499,7 @@ spec:
                 - '1.0'
                 - '2.0'
             authorizer_result_ttl_in_seconds:
-              type: number
+              type: integer
               title: Result TTL (seconds)
               description: TTL for caching authorizer results (0 disables caching)
               minimum: 0
@@ -627,7 +627,7 @@ spec:
                 - ERROR
                 - INFO
             throttling_burst_limit:
-              type: number
+              type: integer
               title: Throttling Burst Limit
               description: Per-route throttling burst limit
             throttling_rate_limit:
@@ -702,7 +702,7 @@ spec:
                     - '1.0'
                     - '2.0'
                 timeout_milliseconds:
-                  type: number
+                  type: integer
                   title: Timeout (ms)
                   description: Custom timeout for this integration in milliseconds (50-30000)
                 credentials_arn:

--- a/modules/common/aws_kms/standard/1.0/facets.yaml
+++ b/modules/common/aws_kms/standard/1.0/facets.yaml
@@ -66,7 +66,7 @@ spec:
       description: Specifies whether key rotation is enabled
       default: true
     deletion_window_in_days:
-      type: number
+      type: integer
       title: Deletion Window (Days)
       description: Waiting period before KMS deletes the key (7-30 days)
       minimum: 7
@@ -211,7 +211,7 @@ spec:
           hosted_zone_arn:
             type: string
     rotation_period_in_days:
-      type: number
+      type: integer
       title: Rotation Period (Days)
       description: Custom period of time between automatic rotations
       minimum: 90

--- a/modules/common/aws_secret_manager/standard/1.0/facets.yaml
+++ b/modules/common/aws_secret_manager/standard/1.0/facets.yaml
@@ -54,7 +54,7 @@ spec:
       description: (Optional) Valid JSON document representing a resource policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide. Removing policy from your configuration or setting policy to null or an empty string (i.e., policy = "") will not delete the policy since it could have been set by aws_secretsmanager_secret_policy. To delete the policy, set it to "{}" (an empty JSON document).
       x-ui-yaml-editor: true
     recovery_window_in_days:
-      type: number
+      type: integer
       title: Recovery Window (Days)
       description: (Optional) Number of days that AWS Secrets Manager waits before it can delete the secret. This value can be 0 to force deletion without recovery or range from 7 to 30 days. The default value is 30.
       default: 30
@@ -80,7 +80,7 @@ spec:
           description: Configuration for rotation schedule
           properties:
             automatically_after_days:
-              type: number
+              type: integer
               title: Automatically After Days
               description: Number of days between automatic scheduled rotations
               minimum: 1

--- a/modules/common/helm/k8s_git/1.0/facets.yaml
+++ b/modules/common/helm/k8s_git/1.0/facets.yaml
@@ -98,7 +98,7 @@ spec:
           description: Wait for the deployment to complete
           default: true
         timeout:
-          type: number
+          type: integer
           title: Timeout (seconds)
           description: Time to wait for deployment completion
           default: 300

--- a/modules/datastore/kafka/aws-msk/1.0/facets.yaml
+++ b/modules/datastore/kafka/aws-msk/1.0/facets.yaml
@@ -68,21 +68,21 @@ spec:
       - client_subnets_count
       properties:
         number_of_broker_nodes:
-          type: number
+          type: integer
           title: Number of Broker Nodes
           description: Number of broker nodes per availability zone
           minimum: 1
           maximum: 15
           default: 3
         volume_size:
-          type: number
+          type: integer
           title: Volume Size (GB)
           description: EBS volume size per broker in GB
           minimum: 1
           maximum: 16384
           default: 100
         client_subnets_count:
-          type: number
+          type: integer
           title: Client Subnets Count
           description: Number of subnets to distribute brokers across (2-3 for multi-AZ)
           minimum: 2

--- a/modules/datastore/kafka/gcp-msk/1.0/facets.yaml
+++ b/modules/datastore/kafka/gcp-msk/1.0/facets.yaml
@@ -46,21 +46,21 @@ spec:
       - disk_size_gb
       properties:
         vcpu_count:
-          type: number
+          type: integer
           title: vCPU Count
           description: Number of virtual CPUs (minimum 3 required)
           minimum: 3
           maximum: 48
           default: 3
         memory_gb:
-          type: number
+          type: integer
           title: Memory (GB)
           description: Memory in gigabytes for the cluster
           minimum: 3
           maximum: 48
           default: 3
         disk_size_gb:
-          type: number
+          type: integer
           title: Disk Size (GB)
           description: Persistent disk size per broker in GB
           minimum: 100
@@ -81,7 +81,7 @@ spec:
           description: Create a Kafka Connect cluster alongside the Kafka cluster
           default: false
         vcpu_count:
-          type: number
+          type: integer
           title: vCPU Count
           description: Number of virtual CPUs for Connect cluster - Default is 12
           minimum: 3
@@ -92,7 +92,7 @@ spec:
             values:
             - true
         memory_gb:
-          type: number
+          type: integer
           title: Memory (GB)
           description: Memory in gigabytes for Connect cluster - Default is 20
           minimum: 3

--- a/modules/datastore/kafka/strimzi/1.0/facets.yaml
+++ b/modules/datastore/kafka/strimzi/1.0/facets.yaml
@@ -46,7 +46,7 @@ spec:
       description: Cluster sizing and resource allocation
       properties:
         replica_count:
-          type: number
+          type: integer
           title: Replica Count
           description: Number of Kafka broker replicas (dual-role controller+broker)
           default: 3
@@ -99,27 +99,27 @@ spec:
       description: Kafka broker configuration
       properties:
         offsets_topic_replication_factor:
-          type: number
+          type: integer
           title: Offsets Topic Replication Factor
           default: 3
           minimum: 1
         transaction_state_log_replication_factor:
-          type: number
+          type: integer
           title: Transaction State Log Replication Factor
           default: 3
           minimum: 1
         transaction_state_log_min_isr:
-          type: number
+          type: integer
           title: Transaction State Log Min ISR
           default: 2
           minimum: 1
         default_replication_factor:
-          type: number
+          type: integer
           title: Default Replication Factor
           default: 3
           minimum: 1
         min_insync_replicas:
-          type: number
+          type: integer
           title: Min In-Sync Replicas
           default: 2
           minimum: 1

--- a/modules/datastore/kafka_topic/strimzi/1.0/facets.yaml
+++ b/modules/datastore/kafka_topic/strimzi/1.0/facets.yaml
@@ -28,13 +28,13 @@ spec:
           description: Configuration for a single Kafka topic
           properties:
             partitions:
-              type: number
+              type: integer
               title: Partitions
               description: Number of partitions for this topic
               default: 1
               minimum: 1
             replication_factor:
-              type: number
+              type: integer
               title: Replication Factor
               description: Number of replicas for each partition across brokers. NOTE - changing this on an existing topic requires Cruise Control enabled on the Kafka cluster; otherwise the change will be rejected by the Strimzi Topic Operator.
               default: 1

--- a/modules/datastore/mongo/aws-documentdb/1.0/facets.yaml
+++ b/modules/datastore/mongo/aws-documentdb/1.0/facets.yaml
@@ -36,7 +36,7 @@ spec:
           - 6.0.0
           default: 4.0.0
         port:
-          type: number
+          type: integer
           title: Port
           description: Port number for DocumentDB cluster
           minimum: 1024
@@ -62,7 +62,7 @@ spec:
           - db.r6g.xlarge
           default: db.t4g.medium
         instance_count:
-          type: number
+          type: integer
           title: Instance Count
           description: Number of instances in the DocumentDB cluster
           minimum: 1

--- a/modules/datastore/mongo/cosmosdb/1.0/facets.yaml
+++ b/modules/datastore/mongo/cosmosdb/1.0/facets.yaml
@@ -50,7 +50,7 @@ spec:
           - consistent_prefix
           default: session
         port:
-          type: number
+          type: integer
           title: Port
           description: Port number for MongoDB connection
           minimum: 1024
@@ -73,7 +73,7 @@ spec:
           - serverless
           default: provisioned
         max_throughput:
-          type: number
+          type: integer
           title: Maximum Throughput (RU/s)
           description: Maximum Request Units per second for autoscale provisioned
             throughput

--- a/modules/datastore/mysql/aws-aurora/1.0/facets.yaml
+++ b/modules/datastore/mysql/aws-aurora/1.0/facets.yaml
@@ -86,7 +86,7 @@ spec:
           maximum: 128
           default: 4
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replica instances to create
           minimum: 0

--- a/modules/datastore/mysql/aws-rds/1.0/facets.yaml
+++ b/modules/datastore/mysql/aws-rds/1.0/facets.yaml
@@ -69,14 +69,14 @@ spec:
           - db.m5.2xlarge
           default: db.t3.small
         allocated_storage:
-          type: number
+          type: integer
           title: Allocated Storage (GB)
           description: Initial storage allocation in GB
           minimum: 20
           maximum: 65536
           default: 100
         max_allocated_storage:
-          type: number
+          type: integer
           title: Max Storage (GB)
           description: Maximum storage for autoscaling (0 to disable)
           minimum: 0
@@ -93,7 +93,7 @@ spec:
           - io2
           default: gp3
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replicas to create
           minimum: 0

--- a/modules/datastore/mysql/flexible_server/1.0/facets.yaml
+++ b/modules/datastore/mysql/flexible_server/1.0/facets.yaml
@@ -97,14 +97,14 @@ spec:
           - MO_Standard_E20ds_v4
           default: B_Standard_B1ms
         storage_gb:
-          type: number
+          type: integer
           title: Storage Size (GB)
           description: Storage capacity in GB
           minimum: 20
           maximum: 16384
           default: 100
         iops:
-          type: number
+          type: integer
           title: IOPS
           description: Provisioned IOPS (if supported by SKU)
           minimum: 360
@@ -128,7 +128,7 @@ spec:
           - P80
           default: P10
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replicas to create. Not supported for Burstable
             SKUs - will be automatically set to 0

--- a/modules/datastore/mysql/gcp-cloudsql/1.0/facets.yaml
+++ b/modules/datastore/mysql/gcp-cloudsql/1.0/facets.yaml
@@ -70,14 +70,14 @@ spec:
           - db-n1-highmem-4
           default: db-n1-standard-1
         disk_size:
-          type: number
+          type: integer
           title: Storage Size (GB)
           description: Initial storage allocation in GB
           minimum: 10
           maximum: 30720
           default: 100
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replicas to create
           minimum: 0

--- a/modules/datastore/postgres/aws-aurora/1.0/facets.yaml
+++ b/modules/datastore/postgres/aws-aurora/1.0/facets.yaml
@@ -88,7 +88,7 @@ spec:
           maximum: 128
           default: 4
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replica instances to create
           minimum: 0

--- a/modules/datastore/postgres/aws-rds/1.0/facets.yaml
+++ b/modules/datastore/postgres/aws-rds/1.0/facets.yaml
@@ -71,14 +71,14 @@ spec:
           - db.m5.xlarge
           default: db.t3.small
         allocated_storage:
-          type: number
+          type: integer
           title: Allocated Storage (GB)
           description: Initial storage allocation in GB
           minimum: 20
           maximum: 65536
           default: 100
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replicas to create
           minimum: 0

--- a/modules/datastore/postgres/azure-flexible-server/1.0/facets.yaml
+++ b/modules/datastore/postgres/azure-flexible-server/1.0/facets.yaml
@@ -81,14 +81,14 @@ spec:
           - MO_Standard_E4s_v3
           default: GP_Standard_D2s_v3
         storage_gb:
-          type: number
+          type: integer
           title: Storage Size (GB)
           description: Storage capacity in gigabytes
           minimum: 32
           maximum: 16384
           default: 128
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replicas to create
           minimum: 0

--- a/modules/datastore/postgres/gcp-cloudsql/1.0/facets.yaml
+++ b/modules/datastore/postgres/gcp-cloudsql/1.0/facets.yaml
@@ -66,14 +66,14 @@ spec:
           - db-custom-16-65536
           default: db-custom-2-7680
         disk_size:
-          type: number
+          type: integer
           title: Disk Size (GB)
           description: Initial disk size in GB
           minimum: 10
           maximum: 30720
           default: 100
         read_replica_count:
-          type: number
+          type: integer
           title: Read Replica Count
           description: Number of read replicas to create
           minimum: 0

--- a/modules/datastore/redis/aws-elasticache/1.0/facets.yaml
+++ b/modules/datastore/redis/aws-elasticache/1.0/facets.yaml
@@ -55,7 +55,7 @@ spec:
       - snapshot_retention_limit
       properties:
         num_cache_nodes:
-          type: number
+          type: integer
           title: Number of Cache Nodes
           description: Number of cache nodes in the cluster (use 2+ for high availability
             with automatic failover)
@@ -68,7 +68,7 @@ spec:
           description: Name of the parameter group to associate with this cache cluster
           default: default.redis7
         snapshot_retention_limit:
-          type: number
+          type: integer
           title: Snapshot Retention (Days)
           description: Number of days for which ElastiCache will retain automatic
             cache cluster snapshots

--- a/modules/datastore/redis/azure_cache_custom/1.0/facets.yaml
+++ b/modules/datastore/redis/azure_cache_custom/1.0/facets.yaml
@@ -70,14 +70,14 @@ spec:
           x-ui-error-message: Premium SKU is required for VNet integration and automatic
             backups
         capacity:
-          type: number
+          type: integer
           title: Cache Capacity
           description: Cache size/capacity (0-6 for Basic/Standard, 1-5 for Premium)
           minimum: 0
           maximum: 6
           default: 1
         replicas_per_master:
-          type: number
+          type: integer
           title: Replicas per Master
           description: Number of replicas per master (Premium only)
           minimum: 1
@@ -88,7 +88,7 @@ spec:
             values:
             - P
         replicas_per_primary:
-          type: number
+          type: integer
           title: Replicas per Primary
           description: Number of replicas per primary node (Premium only)
           minimum: 1
@@ -99,7 +99,7 @@ spec:
             values:
             - P
         shard_count:
-          type: number
+          type: integer
           title: Shard Count
           description: Number of shards for Premium clustered cache
           minimum: 1

--- a/modules/datastore/redis/gcp-memorystore/1.0/facets.yaml
+++ b/modules/datastore/redis/gcp-memorystore/1.0/facets.yaml
@@ -49,7 +49,7 @@ spec:
       - tier
       properties:
         memory_size_gb:
-          type: number
+          type: integer
           title: Memory Size (GB)
           description: Memory allocation in GB for the Redis instance (min 5GB for
             Standard HA tier)

--- a/modules/datastore/redis/logical/1.0/facets.yaml
+++ b/modules/datastore/redis/logical/1.0/facets.yaml
@@ -33,7 +33,7 @@ spec:
         Resolves to the selected resource's full outputs.
       x-ui-output-type: '@facets/redis'
     db_index:
-      type: number
+      type: integer
       title: Logical DB Index
       description: Redis logical database index to target on the shared instance. Use
         a distinct index to separate this logical cache from others sharing the same

--- a/modules/gcs/standard/1.0/facets.yaml
+++ b/modules/gcs/standard/1.0/facets.yaml
@@ -142,7 +142,7 @@ spec:
           description: Age in days after which objects will be transitioned/deleted
           minimum: 0
           title: Age in Days
-          type: number
+          type: integer
         storage_class:
           default: NEARLINE
           description: The target storage class if action is SetStorageClass

--- a/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
@@ -103,7 +103,7 @@ spec:
           x-ui-overrides-only: false
           properties:
             log_group_retention_in_days:
-              type: number
+              type: integer
               title: Log Group Retention In Days
               description: Retention period for the CloudWatch log group.
               default: 90

--- a/modules/network/ovh/1.0/facets.yaml
+++ b/modules/network/ovh/1.0/facets.yaml
@@ -34,7 +34,7 @@ spec:
       description: CIDR block for the private network
       x-ui-overrides-only: true
     vlan_id:
-      type: number
+      type: integer
       title: VLAN ID
       description: VLAN ID for the network (0-4000). Must be unique per OVH account.
       minimum: 0

--- a/modules/object_storage/ovh/1.0/facets.yaml
+++ b/modules/object_storage/ovh/1.0/facets.yaml
@@ -68,7 +68,7 @@ spec:
       description: Enable automatic object lifecycle management
       default: false
     expiration_days:
-      type: number
+      type: integer
       title: Object Expiration Days
       description: Number of days after which objects expire (if lifecycle is enabled)
       default: 0


### PR DESCRIPTION
## Problem

  `type: number` in a `facets.yaml` spec schema accepts floating-point values. A field like `read_replica_count` or `allocated_storage` will happily accept `2.1` or `4.3` at
  schema-validation time and only fail later at the provider. It works by accident today because users happen to type `1`, `2`, `3` — nothing stops `2.1`.

  ## Change

  59 whole-number spec fields across 26 modules switched from `type: number` to `type: integer`.

  **Converted:** replica/node/shard/instance counts · storage & disk GB · memory GB · ports · IOPS · vCPU counts · retention and recovery windows in days · partitions · replication
  factors · min in-sync replicas · throttling burst limits · TTLs · timeouts · VLAN ID · Cosmos RU/s · cache capacity · `db_index`

  ## Deliberately left as `type: number`

  Each module was analysed for whether fractional values are genuinely needed. These 8 fields keep `number`:

  | Module | Field(s) | Why |
  |---|---|---|
  | `datastore/mysql/aws-aurora` | `min_capacity`, `max_capacity` | Aurora Serverless v2 ACU is 0.5-granular — `minimum` is already `0.5` |
  | `datastore/postgres/aws-aurora` | `min_capacity`, `max_capacity` | same |
  | `common/aws_api_gateway` | `throttling_rate_limit` (stage default + per-route) | AWS types `ThrottlingRateLimit` as `Double`; sub-1 rps is valid |
  | `common/aws_efs` | `provisioned_throughput_in_mibps` | AWS types `ProvisionedThroughputInMibps` as `Double` |
  | `alert_policy/gcp` | `condition.threshold` | metric thresholds are ratios and latencies (`0.8`, `0.95`) |

  ## Scope discipline

  - Only `type:` values changed — 59 insertions, 59 deletions, one per field.
  - No `default`, `minimum`, `maximum`, description, ordering or indentation touched.
  - No `.tf` files changed. Terraform's `number` type accepts integers, so `variables.tf` needs no update.
  - Verified: every converted field already had integer `default`/`minimum`/`maximum`, so no schema/sample conflicts were introduced.
  - All 26 files parse via `yaml.safe_load`.

  ## Validation status 

  `raptor create iac-module --dry-run` was run on all 26 modules. The stage this change actually touches passes everywhere:

  ```
  ✅ var.instance.spec validated successfully
  🔍 Terraform validation successful
  ```