### PR TITLE
Add 7 GCP account-layer icons

### DIFF
--- a/icons/gcp_folder.svg
+++ b/icons/gcp_folder.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gcp-folder-gradient" x2="0" y1="7.03" y2="120.79" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4387fd"/>
+      <stop offset="1" stop-color="#4683ea"/>
+    </linearGradient>
+    <clipPath id="gcp-folder-clip">
+      <use xlink:href="#gcp-folder-hex"/>
+    </clipPath>
+    <path id="gcp-folder-hex" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  </defs>
+  <path fill="url(#gcp-folder-gradient)" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  <path d="M124.05 82.86 89.63 48.44 64 37 39.5 50.31l-1.027 29.34 42.547 42.54 16.65-.15z" clip-path="url(#gcp-folder-clip)" opacity=".07"/>
+  <path fill="#fff" d="M40 42h15.2a4 4 0 0 1 3.2 1.6l4 5.4H88a5 5 0 0 1 5 5v31a5 5 0 0 1-5 5H40a5 5 0 0 1-5-5V47a5 5 0 0 1 5-5z"/>
+</svg>

--- a/icons/gcp_kms.svg
+++ b/icons/gcp_kms.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gcp-kms-gradient" x2="0" y1="7.03" y2="120.79" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4387fd"/>
+      <stop offset="1" stop-color="#4683ea"/>
+    </linearGradient>
+    <clipPath id="gcp-kms-clip">
+      <use xlink:href="#gcp-kms-hex"/>
+    </clipPath>
+    <path id="gcp-kms-hex" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  </defs>
+  <path fill="url(#gcp-kms-gradient)" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  <path d="M124.05 82.86 89.63 48.44 64 37 39.5 50.31l-1.027 29.34 42.547 42.54 16.65-.15z" clip-path="url(#gcp-kms-clip)" opacity=".07"/>
+  <path fill="none" stroke="#fff" stroke-width="7" d="M52.5 55.5m-13 0a13 13 0 1 0 26 0a13 13 0 1 0-26 0"/>
+  <path fill="none" stroke="#fff" stroke-width="7" stroke-linecap="round" d="M62 65 88 91"/>
+  <path fill="none" stroke="#fff" stroke-width="7" stroke-linecap="round" d="M80 83 74 89M71 74 65 80"/>
+</svg>

--- a/icons/gcp_log_sink.svg
+++ b/icons/gcp_log_sink.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gcp-log-sink-gradient" x2="0" y1="7.03" y2="120.79" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4387fd"/>
+      <stop offset="1" stop-color="#4683ea"/>
+    </linearGradient>
+    <clipPath id="gcp-log-sink-clip">
+      <use xlink:href="#gcp-log-sink-hex"/>
+    </clipPath>
+    <path id="gcp-log-sink-hex" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  </defs>
+  <path fill="url(#gcp-log-sink-gradient)" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  <path d="M124.05 82.86 89.63 48.44 64 37 39.5 50.31l-1.027 29.34 42.547 42.54 16.65-.15z" clip-path="url(#gcp-log-sink-clip)" opacity=".07"/>
+  <rect fill="#fff" x="40" y="36" width="48" height="6" rx="3"/>
+  <rect fill="#fff" x="46" y="48" width="36" height="6" rx="3"/>
+  <rect fill="#fff" x="52" y="60" width="24" height="6" rx="3"/>
+  <path fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" d="M64 72v10m-8-6 8 8 8-8"/>
+  <path fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round" d="M42 92h44"/>
+</svg>

--- a/icons/gcp_org_policy.svg
+++ b/icons/gcp_org_policy.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gcp-org-policy-gradient" x2="0" y1="7.03" y2="120.79" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4387fd"/>
+      <stop offset="1" stop-color="#4683ea"/>
+    </linearGradient>
+    <clipPath id="gcp-org-policy-clip">
+      <use xlink:href="#gcp-org-policy-hex"/>
+    </clipPath>
+    <path id="gcp-org-policy-hex" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  </defs>
+  <path fill="url(#gcp-org-policy-gradient)" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  <path d="M124.05 82.86 89.63 48.44 64 37 39.5 50.31l-1.027 29.34 42.547 42.54 16.65-.15z" clip-path="url(#gcp-org-policy-clip)" opacity=".07"/>
+  <path fill="#fff" d="M64 33 90 44v21c0 16.5-11 28.6-26 33-15-4.4-26-16.5-26-33V44z"/>
+  <path fill="none" stroke="#4387fd" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" d="M53 65.5 61 74l15-16"/>
+</svg>

--- a/icons/gcp_project.svg
+++ b/icons/gcp_project.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gcp-project-gradient" x2="0" y1="7.03" y2="120.79" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4387fd"/>
+      <stop offset="1" stop-color="#4683ea"/>
+    </linearGradient>
+    <clipPath id="gcp-project-clip">
+      <use xlink:href="#gcp-project-hex"/>
+    </clipPath>
+    <path id="gcp-project-hex" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  </defs>
+  <path fill="url(#gcp-project-gradient)" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  <path d="M124.05 82.86 89.63 48.44 64 37 39.5 50.31l-1.027 29.34 42.547 42.54 16.65-.15z" clip-path="url(#gcp-project-clip)" opacity=".07"/>
+  <path fill="#fff" fill-rule="evenodd" d="M39 38h50a5 5 0 0 1 5 5v42a5 5 0 0 1-5 5H39a5 5 0 0 1-5-5V43a5 5 0 0 1 5-5zm1 7a1 1 0 0 0-1 1v36a1 1 0 0 0 1 1h48a1 1 0 0 0 1-1V46a1 1 0 0 0-1-1z"/>
+  <rect fill="#fff" x="45" y="52" width="15" height="10" rx="2"/>
+  <rect fill="#fff" x="45" y="66" width="15" height="10" rx="2"/>
+  <rect fill="#fff" x="65" y="52" width="18" height="24" rx="2"/>
+</svg>

--- a/icons/gcp_project_iam.svg
+++ b/icons/gcp_project_iam.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gcp-project-iam-gradient" x2="0" y1="7.03" y2="120.79" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4387fd"/>
+      <stop offset="1" stop-color="#4683ea"/>
+    </linearGradient>
+    <clipPath id="gcp-project-iam-clip">
+      <use xlink:href="#gcp-project-iam-hex"/>
+    </clipPath>
+    <path id="gcp-project-iam-hex" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  </defs>
+  <path fill="url(#gcp-project-iam-gradient)" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  <path d="M124.05 82.86 89.63 48.44 64 37 39.5 50.31l-1.027 29.34 42.547 42.54 16.65-.15z" clip-path="url(#gcp-project-iam-clip)" opacity=".07"/>
+  <circle fill="#fff" cx="54" cy="47" r="12"/>
+  <path fill="#fff" d="M54 63c11.6 0 21 9.4 21 21v4H33v-4c0-11.6 9.4-21 21-21z"/>
+  <path fill="#fff" d="M84 64a9 9 0 0 1 9 9v3h1.5a3 3 0 0 1 3 3v13a3 3 0 0 1-3 3H73.5a3 3 0 0 1-3-3V79a3 3 0 0 1 3-3H75v-3a9 9 0 0 1 9-9zm0 6a3 3 0 0 0-3 3v3h6v-3a3 3 0 0 0-3-3z"/>
+</svg>

--- a/icons/gcp_service_account.svg
+++ b/icons/gcp_service_account.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="gcp-service-account-gradient" x2="0" y1="7.03" y2="120.79" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4387fd"/>
+      <stop offset="1" stop-color="#4683ea"/>
+    </linearGradient>
+    <clipPath id="gcp-service-account-clip">
+      <use xlink:href="#gcp-service-account-hex"/>
+    </clipPath>
+    <path id="gcp-service-account-hex" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  </defs>
+  <path fill="url(#gcp-service-account-gradient)" d="M27.791 115.22 1.541 69.75a11.5 11.5 0 0 1 0-11.499l26.25-45.47a11.5 11.5 0 0 1 9.959-5.75h52.5c4.108 0 7.904 2.192 9.959 5.75l26.25 45.47a11.5 11.5 0 0 1 0 11.499l-26.25 45.47a11.5 11.5 0 0 1-9.959 5.749h-52.5a11.5 11.5 0 0 1-9.958-5.749"/>
+  <path d="M124.05 82.86 89.63 48.44 64 37 39.5 50.31l-1.027 29.34 42.547 42.54 16.65-.15z" clip-path="url(#gcp-service-account-clip)" opacity=".07"/>
+  <path fill="#fff" fill-rule="evenodd" d="M64 30a34 34 0 1 1 0 68 34 34 0 0 1 0-68zm0 8a26 26 0 1 0 0 52 26 26 0 0 0 0-52z"/>
+  <path fill="#fff" d="M59.5 24h9l1.2 9.6-11.4 0zM59.5 104h9l1.2-9.6-11.4 0zM24 59.5v9l9.6 1.2 0-11.4zM104 59.5v9l-9.6 1.2 0-11.4z"/>
+  <circle fill="#fff" cx="64" cy="56" r="9"/>
+  <path fill="#fff" d="M64 68c8.3 0 15 6.7 15 15v3H49v-3c0-8.3 6.7-15 15-15z"/>
+</svg>


### PR DESCRIPTION
The GCP account-layer intents had no icons, so their modules were pointing at borrowed ones (`cloud_account.svg`, `aws_kms.svg`) — which reads confusingly in the resource graph when four different intents share one icon.

Adds:

| Icon | Glyph |
|---|---|
| `gcp_folder.svg` | tabbed folder |
| `gcp_project.svg` | frame holding resource blocks |
| `gcp_kms.svg` | key |
| `gcp_org_policy.svg` | shield + check |
| `gcp_log_sink.svg` | log lines draining into a collector |
| `gcp_project_iam.svg` | person + padlock |
| `gcp_service_account.svg` | cog wrapped around a person |

**Style:** each uses the identical frame as the existing `compute_engine.svg` — same 128×128 hexagon path, same `#4387fd → #4683ea` gradient, same `.07`-opacity diagonal shadow clipped to the hex — so they sit alongside the existing GCP icons rather than looking bolted on. Glyphs are original and deliberately geometric, since the UI renders these at roughly 26px where fine detail disappears.

Icons only. No module changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUrizLgzMW6L2S7xPUgqpN