### PR TITLE
fix(schema): move advisory enums to x-ui-dropdown so valid values stop freezing resources (#219)

### DIFF
--- a/modules/common/ingress/nginx_k8s/1.0/facets.yaml
+++ b/modules/common/ingress/nginx_k8s/1.0/facets.yaml
@@ -199,6 +199,17 @@ spec:
               - Vary
               - Content-Disposition
               - X-Tenant-ID
+              x-ui-dropdown:
+              - X-Frame-Options
+              - Content-Security-Policy
+              - Referrer-Policy
+              - X-Content-Type-Options
+              - X-Xss-Protection
+              - reflected-xss
+              - Cache-Control
+              - Vary
+              - Content-Disposition
+              - X-Tenant-ID
             header_value:
               type: string
               title: Header Value
@@ -330,6 +341,17 @@ spec:
                   - Vary
                   - Content-Disposition
                   - X-Tenant-ID
+                  x-ui-dropdown:
+                  - X-Frame-Options
+                  - Content-Security-Policy
+                  - Referrer-Policy
+                  - X-Content-Type-Options
+                  - X-Xss-Protection
+                  - reflected-xss
+                  - Cache-Control
+                  - Vary
+                  - Content-Disposition
+                  - X-Tenant-ID
                 header_value:
                   type: string
                   title: Header Value
@@ -394,6 +416,17 @@ spec:
                         characters and hyphens
                       x-ui-typeable: true
                       enum:
+                      - X-Frame-Options
+                      - Content-Security-Policy
+                      - Referrer-Policy
+                      - X-Content-Type-Options
+                      - X-Xss-Protection
+                      - reflected-xss
+                      - Cache-Control
+                      - Vary
+                      - Content-Disposition
+                      - X-Tenant-ID
+                      x-ui-dropdown:
                       - X-Frame-Options
                       - Content-Security-Policy
                       - Referrer-Policy
@@ -529,6 +562,17 @@ spec:
                               - Vary
                               - Content-Disposition
                               - X-Tenant-ID
+                              x-ui-dropdown:
+                              - X-Frame-Options
+                              - Content-Security-Policy
+                              - Referrer-Policy
+                              - X-Content-Type-Options
+                              - X-Xss-Protection
+                              - reflected-xss
+                              - Cache-Control
+                              - Vary
+                              - Content-Disposition
+                              - X-Tenant-ID
                             header_value:
                               type: string
                               title: Header Value
@@ -567,6 +611,9 @@ spec:
               description: The error code for which the custom page is to be shown
               x-ui-typeable: true
               enum:
+              - '404'
+              - '503'
+              x-ui-dropdown:
               - '404'
               - '503'
             page_content:

--- a/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
+++ b/modules/kubernetes_cluster/eks_automode/1.0/facets.yaml
@@ -167,6 +167,18 @@ spec:
                     - adot
                     - aws-privateca-connector-for-kubernetes
                     - sriov-network-metrics-exporter
+                  x-ui-dropdown:
+                    - aws-efs-csi-driver
+                    - aws-fsx-csi-driver
+                    - aws-mountpoint-s3-csi-driver
+                    - eks-node-monitoring-agent
+                    - snapshot-controller
+                    - aws-network-flow-monitoring-agent
+                    - aws-guardduty-agent
+                    - amazon-cloudwatch-observability
+                    - adot
+                    - aws-privateca-connector-for-kubernetes
+                    - sriov-network-metrics-exporter
                   x-ui-typeable: true
                   x-ui-overrides-only: false
                   x-ui-unique: true


### PR DESCRIPTION
Part of Facets-cloud/raptor#219 (finding 1a). Companion to Facets-cloud/facets-modules#566.

> This description follows the core rules of ASD-STE100 Simplified Technical English: active voice, simple present tense, short sentences, and one meaning for one word.

## The problem

Six fields in this repository pair an `enum` with `x-ui-typeable: true`. This combination has always meant "these values are suggestions; type any value that the pattern permits". The UI obeys this rule. It applies an `enum` only when the field is **not** typeable.

But `enum` is a JSON Schema keyword. A strict validator applies it. raptor is a strict validator, and raptor applies it.

The defect that follows:

1. The user selects a value that is not in the list. The UI accepts it.
2. The control plane stores the value. The control plane does not validate the spec.
3. raptor rejects the resource. `apply` validates the full merged spec, by design.
4. Every later edit fails, also an edit to an unrelated field. The resource is frozen.

Issue raptor#219 describes one occurrence in the legacy `service/deployment/0.1` module. It froze the `service/agent` resource in the `fcp` project.

## The change

The six fields move to `x-ui-dropdown`. This key is not a JSON Schema keyword, so no validator applies it. The UI renders the same dropdown. raptor prints a warning for a value outside the list.

The change is additive. Each field keeps its `enum` and its `x-ui-typeable`, and gains a copy of the list under `x-ui-dropdown`. No line is deleted.

**`enum` and `x-ui-typeable` stay for now.** This is deliberate, and it is temporary. A UI build without `x-ui-dropdown` support reads `enum` for the option list, and `x-ui-typeable` for free entry. Facets-cloud/facets-modules#567 tracks the removal after the frontend release.

| Module | Field | Values | Pattern |
| --- | --- | --- | --- |
| `common/ingress/nginx_k8s/1.0` | `more_set_headers.*.header_name` | 10 | yes |
| `common/ingress/nginx_k8s/1.0` | `rules.*.header_based_routing.header_name` | 10 | yes |
| `common/ingress/nginx_k8s/1.0` | `rules.*.more_set_headers.*.header_name` | 10 | yes |
| `common/ingress/nginx_k8s/1.0` | `rules.*.conditional_set_headers.*.headers.*.header_name` | 10 | yes |
| `common/ingress/nginx_k8s/1.0` | `custom_error_pages.*.error_code` | 2 | no |
| `kubernetes_cluster/eks_automode/1.0` | `cluster.cluster_addons.*.name` | 11 | no |

## Each of the six sets is open

The module code confirms this:

- **HTTP header names.** A user can set any header. The four fields keep their `pattern`, so a check remains.
- **`custom_error_pages.*.error_code`.** `nginx_k8s/1.0/main.tf:223` uses the value as a map key for the error-page config. nginx serves a custom page for any HTTP status code. The list of `404` and `503` was itself a form of this defect: a user could not add a page for status 500.
- **`cluster_addons.*.name`.** AWS releases new EKS addons on its own schedule. `variables.tf` accepts a map of addon names. It does not restrict the names.

No field in this repository needs a closed `enum` restored. The companion PR `facets-modules#566` restores three fields, because their sets are fixed by AWS or by the module itself.

## Testing

**1. The parsed schema is unchanged, except for the intended edits.**

A script loads each `facets.yaml` from `main` and from this branch. It then compares the two trees node by node. Result: 6 fields converted, 0 of them keep `x-ui-typeable`, 0 unexpected differences.

**2. No closed enum is changed.**

No field without `x-ui-typeable` is touched. The count of `enum` fields does not fall, because this PR keeps every one of them. The count of `x-ui-dropdown` fields rises from 0 to 6, and each list matches its `enum` exactly.

**3. `raptor module validate` result is unchanged.**

Both modules pass the validator before and after the change.

**4. The diff is additive.**

2 files, 59 insertions, 0 deletions. The existing lines, the comments, the value order and the line wrapping do not change.

## Every combination works

Each row is verified by a test, not by inspection:

| Module schema | UI build without #643 | UI build with #643 | raptor with #326 |
| --- | --- | --- | --- |
| `enum` + `x-ui-typeable` (unmigrated) | dropdown, free entry | dropdown, free entry | advisory, warns |
| all three keys (the module PRs) | dropdown, free entry | dropdown, free entry | advisory, warns |
| `x-ui-dropdown` only (after cleanup) | plain text input | dropdown, free entry | advisory, warns |

**Release order does not matter.** The module PRs keep `enum` and `x-ui-typeable` beside the new key, so every UI build keeps its dropdown. Facets-cloud/facets-modules#567 tracks the removal of the two old keys after the frontend release.

This change is not breaking. Every value that is valid today stays valid, and every UI build keeps its dropdown.
