### PR TITLE
Add priority_class and network/aws_network_adopt modules

### DIFF
--- a/modules/network/aws_network_adopt/1.0/facets.yaml
+++ b/modules/network/aws_network_adopt/1.0/facets.yaml
@@ -1,0 +1,70 @@
+intent: network
+flavor: aws_network_adopt
+version: '1.0'
+description: Adopts an EXISTING AWS VPC + subnets READ-ONLY (data sources only, creates
+  nothing) so a live/legacy network is managed at zero-change. Supply the live VPC id
+  and the exact subnet ids (public/private/database) from live. Emits the same
+  @facets/aws-vpc-details contract as aws_network so consumers (EKS, etc.) are unchanged.
+intentDetails:
+  type: Cloud & Infrastructure
+  description: Read-only adoption of an existing AWS VPC for zero-change import
+  displayName: Network (Adopt Existing)
+  iconUrl: https://raw.githubusercontent.com/Facets-cloud/facets-modules-redesign/main/icons/network.svg
+clouds:
+- aws
+spec:
+  type: object
+  properties:
+    existing_vpc_id:
+      type: string
+      title: Existing VPC ID
+      description: The id of the live VPC to adopt (e.g. vpc-0014f7b4f85d1b400)
+      x-ui-overrides-only: true
+    private_subnet_ids:
+      type: array
+      title: Private Subnet IDs
+      description: Exact private subnet ids from the live VPC
+      items:
+        type: string
+      x-ui-overrides-only: true
+    public_subnet_ids:
+      type: array
+      title: Public Subnet IDs
+      description: Exact public subnet ids from the live VPC
+      items:
+        type: string
+      x-ui-overrides-only: true
+    database_subnet_ids:
+      type: array
+      title: Database Subnet IDs
+      description: Exact database subnet ids from the live VPC (optional)
+      items:
+        type: string
+      x-ui-overrides-only: true
+  required:
+  - existing_vpc_id
+  - private_subnet_ids
+inputs:
+  cloud_account:
+    type: '@facets/aws_cloud_account'
+    displayName: Cloud Account
+    description: The AWS Cloud Account the VPC lives in
+    optional: false
+    providers:
+    - aws
+outputs:
+  default:
+    type: '@facets/aws-vpc-details'
+sample:
+  kind: network
+  flavor: aws_network_adopt
+  version: '1.0'
+  spec:
+    existing_vpc_id: vpc-0000000000000000
+    private_subnet_ids:
+    - subnet-000000000000000a
+    public_subnet_ids:
+    - subnet-000000000000000b
+iac:
+  validated_files:
+  - variables.tf

--- a/modules/network/aws_network_adopt/1.0/main.tf
+++ b/modules/network/aws_network_adopt/1.0/main.tf
@@ -1,0 +1,31 @@
+# Pure ADOPT module: reads an existing VPC + subnets read-only.
+# Creates NOTHING -> a plan against a live VPC is 0 create / 0 change / 0 destroy.
+
+locals {
+  spec         = var.instance.spec
+  vpc_id       = local.spec.existing_vpc_id
+  public_ids   = tolist(lookup(local.spec, "public_subnet_ids", []))
+  private_ids  = tolist(lookup(local.spec, "private_subnet_ids", []))
+  database_ids = tolist(lookup(local.spec, "database_subnet_ids", []))
+  all_ids      = toset(concat(local.public_ids, local.private_ids, local.database_ids))
+}
+
+data "aws_vpc" "this" {
+  id = local.vpc_id
+}
+
+data "aws_subnet" "this" {
+  for_each = local.all_ids
+  id       = each.value
+}
+
+data "aws_internet_gateway" "this" {
+  filter {
+    name   = "attachment.vpc-id"
+    values = [local.vpc_id]
+  }
+}
+
+data "aws_nat_gateways" "this" {
+  vpc_id = local.vpc_id
+}

--- a/modules/network/aws_network_adopt/1.0/outputs.tf
+++ b/modules/network/aws_network_adopt/1.0/outputs.tf
@@ -1,0 +1,20 @@
+locals {
+  output_attributes = {
+    vpc_id                          = data.aws_vpc.this.id
+    vpc_cidr_block                  = data.aws_vpc.this.cidr_block
+    nat_gateway_ids                 = data.aws_nat_gateways.this.ids
+    public_subnet_ids               = local.public_ids
+    private_subnet_ids              = local.private_ids
+    database_subnet_ids             = local.database_ids
+    database_subnet_group_name      = null
+    internet_gateway_id             = data.aws_internet_gateway.this.id
+    availability_zones              = distinct([for s in data.aws_subnet.this : s.availability_zone])
+    vpc_endpoint_s3_id              = null
+    vpc_endpoint_dynamodb_id        = null
+    vpc_endpoint_ecr_api_id         = null
+    vpc_endpoint_ecr_dkr_id         = null
+    vpc_endpoints_security_group_id = null
+  }
+  output_interfaces = {
+  }
+}

--- a/modules/network/aws_network_adopt/1.0/variables.tf
+++ b/modules/network/aws_network_adopt/1.0/variables.tf
@@ -1,0 +1,45 @@
+variable "instance_name" {
+  description = "Name of the instance"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment configuration"
+  type = object({
+    name        = string
+    unique_name = string
+    cloud_tags  = map(string)
+  })
+}
+
+variable "inputs" {
+  description = "Input references from other modules"
+  type = object({
+    cloud_account = object({
+      attributes = optional(object({
+        aws_iam_role = optional(string)
+        aws_region   = optional(string)
+        external_id  = optional(string)
+        session_name = optional(string)
+      }))
+      interfaces = optional(object({}))
+    })
+  })
+}
+
+variable "instance" {
+  description = "Instance configuration (adopt: existing_vpc_id + subnet ids)"
+  type        = any
+
+  # Must supply an existing VPC id to adopt.
+  validation {
+    condition     = try(length(var.instance.spec.existing_vpc_id) > 0, false)
+    error_message = "existing_vpc_id is required and must be a non-empty VPC id (e.g. vpc-0123...)."
+  }
+
+  # Must supply at least one private subnet id.
+  validation {
+    condition     = try(length(var.instance.spec.private_subnet_ids) > 0, false)
+    error_message = "private_subnet_ids must list at least one existing subnet id."
+  }
+}

--- a/modules/priority_class/standard/1.0/facets.yaml
+++ b/modules/priority_class/standard/1.0/facets.yaml
@@ -1,0 +1,96 @@
+intent: priority_class
+flavor: standard
+version: '1.0'
+description: Creates cluster-scoped Kubernetes PriorityClasses
+intentDetails:
+  type: Kubernetes Resources
+  description: Cluster-scoped Kubernetes PriorityClasses for pod scheduling priority
+  displayName: Priority Class
+  iconUrl: https://raw.githubusercontent.com/Facets-cloud/facets-modules-redesign/main/icons/k8s_resource.svg
+clouds:
+- aws
+- azure
+- gcp
+- kubernetes
+inputs:
+  kubernetes_details:
+    type: '@facets/kubernetes-details'
+    displayName: Kubernetes Cluster
+    optional: false
+    default:
+      resource_type: kubernetes_cluster
+      resource_name: default
+    providers:
+    - kubernetes
+    - kubernetes-alpha
+    - helm
+outputs:
+  default:
+    type: '@facets/k8s_resource'
+    title: Priority Class Details
+spec:
+  title: Priority Classes
+  description: Cluster-scoped PriorityClasses. Several redesign modules reference these by name (e.g.
+    vpa sets priorityClassName facets-critical), and Kubernetes REJECTS any pod whose priorityClassName
+    does not exist - so the cluster must have them.
+  type: object
+  properties:
+    priority_classes:
+      type: object
+      title: Priority Classes
+      description: Map of PriorityClass name to definition.
+      patternProperties:
+        ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$:
+          type: object
+          title: Priority Class
+          properties:
+            value:
+              type: integer
+              title: Value
+              description: Priority integer. Higher wins. IMMUTABLE - must match live exactly when adopting
+                an existing PriorityClass.
+            global_default:
+              type: boolean
+              title: Global Default
+              description: Use for pods that specify no priorityClassName. At most one per cluster.
+              default: false
+            description:
+              type: string
+              title: Description
+              description: Free text. Leave unset when adopting - live objects often have none.
+            preemption_policy:
+              type: string
+              title: Preemption Policy
+              enum:
+              - PreemptLowerPriority
+              - Never
+              description: IMMUTABLE. Defaults to PreemptLowerPriority when unset. Set explicitly only
+                when adopting a live PriorityClass created with a different policy.
+            metadata:
+              type: object
+              title: Metadata
+              properties:
+                labels:
+                  type: object
+                  title: Labels
+                  x-ui-yaml-editor: true
+                annotations:
+                  type: object
+                  title: Annotations
+                  x-ui-yaml-editor: true
+          required:
+          - value
+  required:
+  - priority_classes
+sample:
+  kind: priority_class
+  flavor: standard
+  version: '1.0'
+  disabled: false
+  spec:
+    priority_classes:
+      infra-critical:
+        value: 1000
+iac:
+  validated_files:
+  - variables.tf

--- a/modules/priority_class/standard/1.0/main.tf
+++ b/modules/priority_class/standard/1.0/main.tf
@@ -1,0 +1,23 @@
+locals {
+  spec             = lookup(var.instance, "spec", {})
+  priority_classes = lookup(local.spec, "priority_classes", {})
+}
+
+# Cluster-scoped PriorityClasses.
+# NOTE: `value` and `preemption_policy` are IMMUTABLE on a PriorityClass — when adopting an existing
+# one they must match live exactly or the import forces a destroy+recreate, which would leave every
+# pod referencing it unschedulable.
+resource "kubernetes_priority_class_v1" "priority_class" {
+  for_each = local.priority_classes
+
+  metadata {
+    name        = each.key
+    labels      = lookup(lookup(each.value, "metadata", {}), "labels", null)
+    annotations = lookup(lookup(each.value, "metadata", {}), "annotations", null)
+  }
+
+  value             = each.value.value
+  global_default    = lookup(each.value, "global_default", false)
+  description       = lookup(each.value, "description", null)
+  preemption_policy = lookup(each.value, "preemption_policy", null)
+}

--- a/modules/priority_class/standard/1.0/outputs.tf
+++ b/modules/priority_class/standard/1.0/outputs.tf
@@ -1,0 +1,8 @@
+locals {
+  output_interfaces = {}
+  output_attributes = {
+    # PriorityClasses are cluster-scoped, so there is no namespace; the name lists the managed set.
+    resource_name      = join(",", sort([for k, v in kubernetes_priority_class_v1.priority_class : v.metadata[0].name]))
+    resource_namespace = ""
+  }
+}

--- a/modules/priority_class/standard/1.0/variables.tf
+++ b/modules/priority_class/standard/1.0/variables.tf
@@ -1,0 +1,19 @@
+variable "instance" {
+  description = "The resource object from the Facets blueprint"
+  type        = any
+}
+
+variable "instance_name" {
+  description = "Architectural name of the resource in the blueprint"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment context"
+  type        = any
+}
+
+variable "inputs" {
+  description = "Input dependencies from other modules"
+  type        = any
+}


### PR DESCRIPTION
Two new modules. **No existing module is touched** — 8 files, 312 lines.

### `priority_class/standard/1.0`
Cluster-scoped Kubernetes PriorityClasses.

Several modules in this repo set `priorityClassName` (e.g. `vpa` → `facets-critical`), and Kubernetes **rejects** any pod whose priority class doesn't exist — so the cluster has to have them.

The two places that create PriorityClasses today are both single-purpose and hardcoded:
- `artifactories` creates exactly one, `<name>-ecr-token-refresher`
- the utility `app-chart` templates one per service, name derived from the chart

Neither can declare arbitrary cluster-scoped classes, and neither exposes `preemption_policy` — which is immutable and differs on live clusters.

### `network/aws_network_adopt/1.0`
Represents a VPC that already exists. Four `data` sources, **zero `resource` blocks**, so it cannot create, change or destroy anything. It publishes the same output attributes as `aws_network` (`vpc_id`, `vpc_cidr_block`, subnet id lists, `internet_gateway_id`, `nat_gateway_ids`, `availability_zones`), so EKS / ALB / EFS wire up identically.

`aws_network` can't cover this case:
- `aws_vpc.main` is a managed resource with no data-source alternative and no existing-VPC input
- every subnet is hard-wired to `aws_vpc.main.id`
- subnet CIDRs come from `cidrsubnets()` math — there's no input for real CIDRs or real subnet IDs
- it always allocates **3 × num_azs** subnets (private/public/database per AZ), so a legacy flat-subnet VPC can't map onto its address set at any AZ count

Open question for review: `aws_network_adopt` may not be the right flavour name — variants here are named by mode/technology (`eks_standard`, `eks_automode`, `aws_provider`) rather than by action. Happy to rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)