### PR TITLE
fix(eks_standard): admit default_node_pool into the instance spec type

### DIFF
--- a/modules/kubernetes_cluster/eks_standard/1.0/variables.tf
+++ b/modules/kubernetes_cluster/eks_standard/1.0/variables.tf
@@ -35,6 +35,15 @@ variable "instance" {
         })), {})
       }), {})
 
+      # Defaults mirror the fallbacks in main.tf's lookup() chain, so an omitted
+      # block behaves exactly as before this attribute existed.
+      default_node_pool = optional(object({
+        instance_types = optional(list(string), ["t3.medium"])
+        capacity_type  = optional(string, "ON_DEMAND")
+        size           = optional(number, 2)
+        disk_size      = optional(number, 50)
+      }), {})
+
       container_insights_enabled = optional(bool, false)
 
       cloudwatch_agent_policies = optional(map(object({


### PR DESCRIPTION
## Problem

`spec.default_node_pool` is advertised in `facets.yaml:253` and read in `main.tf:24-31`, but it was never declared in the `object()` type constraint on `var.instance.spec` in `variables.tf`.

Terraform **discards object attributes that a type constraint does not declare** — no error, no warning. So the key was stripped at the variable boundary, and `main.tf`'s defensive `lookup()` chain fell through to its hardcoded fallbacks on every apply:

| authored | actually built |
|---|---|
| `instance_types` | `["t3.medium"]` |
| `capacity_type` | `ON_DEMAND` |
| `size` | min = max = desired = `2` |
| `disk_size` | `50` |

The failure is **silent and invisible from the UI**: the control plane validates against `facets.yaml`, so it accepts, stores and displays whatever the user authored, while Terraform builds something else.

## Reproduction

Feeding a realistic spec into a `variable` typed the way this module types it, then evaluating the literal expressions from `main.tf`:

```
# input: default_node_pool = { instance_types = ["t3a.2xlarge"], size = 10, disk_size = 100 }

_1_keys_that_survived                    = ["cluster_tags", "cluster_version"]
_2_lookup_default_node_pool              = "<<KEY ABSENT - fallback returned>>"
_3_instance_types_as_main_tf_computes_it = ["t3.medium"]
_4_desired_size_as_main_tf_computes_it   = 2
```

Confirmed live, not just in a harness: a real blueprint held `{instance_types: ["t3.large"], size: 3, disk_size: 100}` in the control plane while the applied node group came up as 2 × t3.medium.

## Fix

Declare `default_node_pool` in the type constraint, with per-attribute defaults **identical to the existing fallbacks in `main.tf`**. `main.tf` is untouched — its `lookup()` chain simply starts finding real values.

## Backwards compatibility

A spec that omits the block behaves exactly as before. Verified both directions:

| spec | `instance_types` | `size` |
|---|---|---|
| `default_node_pool` authored | `["t3a.2xlarge"]` ✅ | `10` ✅ |
| `default_node_pool` omitted | `["t3.medium"]` (unchanged) | `2` (unchanged) |

## Known limitation, not addressed here

`disk_size` stays inert after this change, for an **unrelated** reason: upstream `terraform-aws-eks` honours `disk_size` only when `use_custom_launch_template = false` (it defaults `true`), and `main.tf` sets no `block_device_mappings`. Nodes therefore still get the AMI default root volume, unencrypted. That deserves its own PR.

## Related

`cluster_addons.metrics_server` has the same defect — advertised in `facets.yaml:84,185`, read in `main.tf:99`, absent from the `cluster_addons` object type. Not fixed here to keep this PR narrow; `additional_addons` is a `map()` and works as a viable workaround today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)