### PR TITLE
fix(aws-rds): expose master_username, add t4g classes, pg minors and multi_az

### DIFF
--- a/modules/datastore/mysql/aws-rds/1.0/facets.yaml
+++ b/modules/datastore/mysql/aws-rds/1.0/facets.yaml
@@ -27,7 +27,17 @@ spec:
       x-ui-order:
       - version
       - database_name
+      - master_username
       properties:
+        master_username:
+          type: string
+          title: Master Username
+          description: Master username for the database. Leave blank to use the default,
+            'admin'. Cannot be a MySQL reserved word.
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 16
+          default: admin
         version:
           type: string
           title: MySQL Version
@@ -54,6 +64,7 @@ spec:
       - max_allocated_storage
       - storage_type
       - read_replica_count
+      - multi_az
       properties:
         instance_class:
           type: string
@@ -64,6 +75,10 @@ spec:
           - db.t3.small
           - db.t3.medium
           - db.t3.large
+          - db.t4g.micro
+          - db.t4g.small
+          - db.t4g.medium
+          - db.t4g.large
           - db.m5.large
           - db.m5.xlarge
           - db.m5.2xlarge
@@ -99,6 +114,12 @@ spec:
           minimum: 0
           maximum: 5
           default: 0
+        multi_az:
+          type: boolean
+          title: Multi-AZ
+          description: Deploy a standby in a second availability zone. Roughly doubles
+            instance and storage cost. Disable to match a single-AZ source instance.
+          default: true
     restore_config:
       type: object
       title: Restore Operations

--- a/modules/datastore/mysql/aws-rds/1.0/locals.tf
+++ b/modules/datastore/mysql/aws-rds/1.0/locals.tf
@@ -27,7 +27,7 @@ locals {
   is_restore_operation = var.instance.spec.restore_config.restore_from_backup
 
   # When importing, username and password should be same as the original to avoid overriding existing values
-  master_username = local.is_restore_operation ? var.instance.spec.restore_config.restore_master_username : "admin"
+  master_username = local.is_restore_operation ? var.instance.spec.restore_config.restore_master_username : var.instance.spec.version_config.master_username
   master_password = local.is_restore_operation ? var.instance.spec.restore_config.restore_master_password : random_password.master_password[0].result
 
   # Database name - should be same when importing
@@ -39,9 +39,11 @@ locals {
   # Port mapping for MySQL
   mysql_port = 3306
 
-  # Performance Insights support - only supported on certain instance classes
-  # db.t3.micro and db.t3.small don't support Performance Insights
-  performance_insights_supported = !contains(["db.t3.micro", "db.t3.small"], var.instance.spec.sizing.instance_class)
+  # Performance Insights support - only supported on certain instance classes.
+  # Confirmed against describe-orderable-db-instance-options for mysql 8.4.9 in ap-south-1:
+  # SupportsPerformanceInsights=false for db.t3.micro, db.t3.small, db.t4g.micro and db.t4g.small.
+  # The t4g entries matter as much as the t3 ones - enabling PI on an unsupported class fails at apply.
+  performance_insights_supported = !contains(["db.t3.micro", "db.t3.small", "db.t4g.micro", "db.t4g.small"], var.instance.spec.sizing.instance_class)
 
   # Enhanced Security Group Logic
   # Detect if security group exists by name (when not explicitly importing)

--- a/modules/datastore/mysql/aws-rds/1.0/main.tf
+++ b/modules/datastore/mysql/aws-rds/1.0/main.tf
@@ -150,7 +150,7 @@ resource "aws_db_instance" "mysql" {
   publicly_accessible    = false # Always private for security
 
   # High availability and backup configuration (hardcoded for security)
-  multi_az                = true                  # Enable HA by default
+  multi_az                = var.instance.spec.sizing.multi_az
   backup_retention_period = 7                     # 7 days retention
   backup_window           = "03:00-04:00"         # 3-4 AM UTC
   maintenance_window      = "sun:04:00-sun:05:00" # Sunday 4-5 AM UTC

--- a/modules/datastore/mysql/aws-rds/1.0/variables.tf
+++ b/modules/datastore/mysql/aws-rds/1.0/variables.tf
@@ -6,9 +6,11 @@ variable "instance" {
     version = string
     spec = object({
       version_config = object({
-        version         = string
-        database_name   = string
-        master_username = string
+        version       = string
+        database_name = string
+        # Optional: falls back to "admin", which is what locals.tf used unconditionally
+        # before this attribute was reachable from the spec.
+        master_username = optional(string, "admin")
       })
       sizing = object({
         instance_class        = string
@@ -16,6 +18,9 @@ variable "instance" {
         max_allocated_storage = number
         storage_type          = string
         read_replica_count    = number
+        # Optional: defaults to true, which is what main.tf hardcoded before this
+        # attribute existed. Set false to match a single-AZ source instance.
+        multi_az = optional(bool, true)
       })
       restore_config = optional(object({
         restore_from_backup           = bool
@@ -39,7 +44,7 @@ variable "instance" {
   }
 
   validation {
-    condition     = contains(["db.t3.micro", "db.t3.small", "db.t3.medium", "db.t3.large", "db.m5.large", "db.m5.xlarge", "db.m5.2xlarge"], var.instance.spec.sizing.instance_class)
+    condition     = contains(["db.t3.micro", "db.t3.small", "db.t3.medium", "db.t3.large", "db.t4g.micro", "db.t4g.small", "db.t4g.medium", "db.t4g.large", "db.m5.large", "db.m5.xlarge", "db.m5.2xlarge"], var.instance.spec.sizing.instance_class)
     error_message = "Instance class must be a valid RDS instance type"
   }
 

--- a/modules/datastore/postgres/aws-rds/1.0/facets.yaml
+++ b/modules/datastore/postgres/aws-rds/1.0/facets.yaml
@@ -28,7 +28,17 @@ spec:
       x-ui-order:
       - engine_version
       - database_name
+      - master_username
       properties:
+        master_username:
+          type: string
+          title: Master Username
+          description: Master username for the database. Leave blank to use the default,
+            'pgadmin'. Cannot be a PostgreSQL reserved word.
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 63
+          default: pgadmin
         engine_version:
           type: string
           title: PostgreSQL Version
@@ -37,8 +47,10 @@ spec:
           - '14.21'
           - '15.16'
           - '16.12'
+          - '16.13'
           - '17.8'
           - '18.1'
+          - '18.3'
           default: '18.1'
         database_name:
           type: string
@@ -58,6 +70,7 @@ spec:
       - instance_class
       - allocated_storage
       - read_replica_count
+      - multi_az
       properties:
         instance_class:
           type: string
@@ -67,6 +80,10 @@ spec:
           - db.t3.micro
           - db.t3.small
           - db.t3.medium
+          - db.t4g.micro
+          - db.t4g.small
+          - db.t4g.medium
+          - db.t4g.large
           - db.m5.large
           - db.m5.xlarge
           default: db.t3.small
@@ -84,6 +101,12 @@ spec:
           minimum: 0
           maximum: 5
           default: 0
+        multi_az:
+          type: boolean
+          title: Multi-AZ
+          description: Deploy a standby in a second availability zone. Roughly doubles
+            instance and storage cost. Disable to match a single-AZ source instance.
+          default: true
       required:
       - instance_class
       - allocated_storage

--- a/modules/datastore/postgres/aws-rds/1.0/main.tf
+++ b/modules/datastore/postgres/aws-rds/1.0/main.tf
@@ -56,7 +56,7 @@ locals {
   replica_identifier_base = local.is_importing ? substr("${local.base_cleaned}imp", 0, 47) : substr(local.db_instance_identifier, 0, 52)
 
   # Master credentials
-  master_username = var.instance.spec.restore_config.restore_from_backup ? var.instance.spec.restore_config.master_username : "pgadmin"
+  master_username = var.instance.spec.restore_config.restore_from_backup ? var.instance.spec.restore_config.master_username : var.instance.spec.version_config.master_username
   master_password = var.instance.spec.restore_config.restore_from_backup ? var.instance.spec.restore_config.master_password : random_password.master_password[0].result
 
   # Database configuration
@@ -170,8 +170,8 @@ resource "aws_db_instance" "postgres" {
   maintenance_window      = local.maintenance_window
   copy_tags_to_snapshot   = true
 
-  # High availability (hardcoded for production readiness)
-  multi_az = true
+  # High availability
+  multi_az = var.instance.spec.sizing.multi_az
 
   # Monitoring (disable enhanced monitoring to avoid IAM role requirement)
   monitoring_interval          = 0

--- a/modules/datastore/postgres/aws-rds/1.0/variables.tf
+++ b/modules/datastore/postgres/aws-rds/1.0/variables.tf
@@ -8,11 +8,17 @@ variable "instance" {
       version_config = object({
         engine_version = string
         database_name  = string
+        # Optional: falls back to "pgadmin", which is what main.tf used unconditionally
+        # before this attribute was reachable from the spec.
+        master_username = optional(string, "pgadmin")
       })
       sizing = object({
         instance_class     = string
         allocated_storage  = number
         read_replica_count = number
+        # Optional: defaults to true, which is what main.tf hardcoded before this
+        # attribute existed. Set false to match a single-AZ source instance.
+        multi_az = optional(bool, true)
       })
       security_config = object({
         deletion_protection = bool


### PR DESCRIPTION
Four gaps that together made it impossible to express 22 real RDS instances (18× mysql 8.4.9, 1× 8.4.8, 1× postgres 18.3, 2× postgres 16.13 — all `db.t4g.*`, all single-AZ).

## 1. `mysql/aws-rds` could not produce a plan at all

`variables.tf:11` declared `spec.version_config.master_username` as a **non-optional** attribute; `facets.yaml` never exposed it. No schema-conformant spec could satisfy the type:

```
Error: Invalid value for input variable
attribute "spec": attribute "version_config": attribute "master_username" is required.
```

`terraform validate` passed, `terraform plan` failed. The attribute was also **dead code** — `locals.tf:30` computed `master_username = is_restore ? … : "admin"` and never read it.

`master_username` is now optional (default `"admin"`), exposed in `facets.yaml`, and actually read by `locals.tf`. `postgres/aws-rds` gets the same treatment (default `"pgadmin"`, previously hardcoded at `main.tf:59`). This also closes the separate "every replica is `admin@`" deviation — the source uses `root` ×18, `admin` ×1, `auctomateroot` ×1, `postgres` ×2.

## 2. Neither instance-class enum contained a `t4g` class

`describe-orderable-db-instance-options` confirms Graviton is orderable in ap-south-1 for both engines. Added `db.t4g.micro/small/medium/large` to both modules — and to the mysql **Terraform validation** in lockstep, since that would otherwise reject what the schema now permits.

**The Performance Insights guard had to widen with it.** `SupportsPerformanceInsights = false` for `db.t4g.micro` and `db.t4g.small` as well as their t3 equivalents. Adding the classes without widening `locals.tf`'s guard would have failed at apply on exactly the smallest and most common instances — 21 of the 22 here are `t4g.micro` or `t4g.small`.

## 3. `postgres/aws-rds`'s version enum omitted current minors

Enum was `14.21 / 15.16 / 16.12 / 17.8 / 18.1`. Real instances run **16.13** and **18.3**. There is no blueprint-side workaround — the control plane enforces the enum server-side:

```
/spec/version_config/engine_version: value must be one of "14.21", "15.16", "16.12", "17.8", "18.1"
/spec/sizing/instance_class:         value must be one of "db.t3.micro", …
```

Worth noting the enum was also *below* every source version, and RDS restores same-or-later only — so the old enum silently forfeited the module's own snapshot-restore path.

## 4. Both modules hardcoded `multi_az = true`

`mysql main.tf:153`, `postgres main.tf:174`. A single-AZ source could not be reproduced, and every replica silently doubled in instance and storage cost. Now a spec field defaulting to `true`.

## Backwards compatibility

Verified in all three directions against the real `variable "instance"` blocks:

| case | mysql user | pg user | multi_az | class / version |
|---|---|---|---|---|
| source config, `master_username` **omitted** | `admin` | `pgadmin` | `false` | `db.t4g.micro`, pg `16.13` |
| `master_username` supplied | `root` | `postgres` | `false` | `db.t4g.medium`, pg `18.3` |
| **existing consumer, no new fields** | `admin` | `pgadmin` | `true` | `db.t3.small`, pg `18.1` |

The third row is identical to pre-patch behaviour, so no existing consumer changes.

## Not addressed here

Deliberately scoped. Still missing for full parity with these instances: `kms_key_id`, `parameter_group_name`, `backup_retention_period`, security-group ingress CIDRs, `deletion_protection` on mysql (postgres already has it), `snapshot_identifier` on mysql (its only restore mode is point-in-time, which is same-account only — so there is no cross-account data path for MySQL today), and consuming the network module's `database_subnet_ids`/`database_subnet_group_name` rather than the EKS private subnets.

Separately: `postgres/aws-rds/outputs.tf:20-31` emits a malformed DSN — it uses `.endpoint` (which already carries `:5432`) as host and then appends `.port` again, yielding `postgres://user:pass@host:5432:5432/db`. The mysql module correctly uses `.address`. Not fixed here to keep this PR reviewable.

## Validation

`terraform fmt` clean. `raptor create iac-module --dry-run` passes every stage on both modules, including `var.instance.spec validated successfully`. Trivy reports pre-existing findings unrelated to this change: mysql `AWS-0080` + `AWS-0104`, postgres `AWS-0104` — all in resource blocks this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)