### PR TITLE
feat(aws-rds-blackbuck): migration-parity RDS flavors for onboarding an existing estate

### DIFF
--- a/modules/datastore/mysql/aws-rds-blackbuck/1.0/README.md
+++ b/modules/datastore/mysql/aws-rds-blackbuck/1.0/README.md
@@ -1,0 +1,62 @@
+# MySQL RDS Database Module v1.0
+
+## Overview
+
+This Facets module provisions a managed MySQL database instance on AWS RDS with high availability, automated backups, and read replicas. The module provides a secure, production-ready MySQL database with encryption at rest and in transit, following AWS best practices for database deployment.
+
+## Environment as Dimension
+
+This module is environment-aware and will create unique resources per environment using the `var.environment.unique_name` for resource naming. Database configurations remain consistent across environments, but networking and scaling settings can be adjusted per environment through the spec configuration.
+
+## Resources Created
+
+- **RDS MySQL Instance**: Primary database instance with specified version and sizing
+- **DB Subnet Group**: Private subnet group for database networking within VPC
+- **Security Group**: Dedicated security group allowing MySQL access (port 3306) from VPC CIDR
+- **Read Replicas**: Optional read-only database replicas for improved read performance
+- **Random Password**: Automatically generated secure master password (16 characters with special characters)
+
+## Security Considerations
+
+### Password Management
+This module uses **random password generation only** and does not utilize AWS Secrets Manager. The generated password is stored in Terraform state and made available through the module's output interfaces. For production deployments, consider implementing external secret management solutions.
+
+### Network Security
+- Database instances are deployed in private subnets only (never publicly accessible)
+- Security group restricts access to MySQL port 3306 from VPC CIDR block only
+- All connections use encryption in transit (SSL/TLS)
+
+### Data Protection
+- Storage encryption at rest is always enabled using AWS managed keys
+- Automated backups are configured with 7-day retention period
+- High availability is enabled by default with Multi-AZ deployment
+- Final snapshots are created before deletion (disabled for testing environments)
+
+### Performance and Monitoring
+- Performance Insights enabled for supported instance classes (disabled for db.t3.micro and db.t3.small)
+- CloudWatch logs exports enabled for error, general, and slow query logs
+- Monitoring interval disabled to avoid IAM role requirements
+
+## Restore Operations
+
+The module supports restoring from existing RDS backups or snapshots by setting `restore_from_backup: true` and providing:
+- Source database instance identifier
+- Restored database master username
+- Restored database master password
+
+When restoring, the module uses the provided credentials instead of generating new ones.
+
+## Import Support
+
+Existing AWS RDS resources can be imported into this module using the import configuration:
+- **DB Instance**: Import existing RDS instance using its identifier
+- **DB Subnet Group**: Import existing subnet group by name  
+- **Security Group**: Import existing security group by ID
+
+## Best Practices
+
+- Instance classes db.t3.micro and db.t3.small do not support Performance Insights
+- Read replicas are created in the same VPC and security group as the primary instance
+- Storage autoscaling is configured when max_allocated_storage is greater than allocated_storage
+- Backup and maintenance windows are scheduled during low-traffic periods (3-4 AM UTC)
+- All resources include comprehensive tagging for resource management and cost allocation

--- a/modules/datastore/mysql/aws-rds-blackbuck/1.0/facets.yaml
+++ b/modules/datastore/mysql/aws-rds-blackbuck/1.0/facets.yaml
@@ -1,0 +1,367 @@
+intent: mysql
+flavor: aws-rds-blackbuck
+version: '1.0'
+clouds:
+- aws
+description: 'MIGRATION-ONLY flavor. Reproduces an existing AWS RDS MySQL estate
+  faithfully, exposing configuration the standard aws-rds flavor deliberately hides
+  (KMS key, parameter group, backup retention, security-group ingress, subnet tier).
+  It intentionally departs from datastore_module_standards.md, which forbids these
+  ops-centric fields. Use aws-rds for greenfield databases; use this only to onboard
+  a pre-existing estate.'
+intentDetails:
+  type: Datastores
+  description: AWS RDS MySQL managed database service
+  displayName: MySQL
+  iconUrl: https://raw.githubusercontent.com/Facets-cloud/facets-modules-redesign/main/icons/mysql.svg
+spec:
+  title: MySQL RDS Database (migration parity)
+  description: Managed MySQL database instance on AWS RDS with high availability,
+    automated backups, and read replicas
+  type: object
+  x-ui-order:
+  - version_config
+  - sizing
+  - security_config
+  - parameter_group
+  - backup_config
+  - network_config
+  - restore_config
+  - imports
+  properties:
+    version_config:
+      type: object
+      title: Version & Basic Configuration
+      x-ui-order:
+      - version
+      - database_name
+      - master_username
+      properties:
+        master_username:
+          type: string
+          title: Master Username
+          description: Master username for the database. Leave blank to use the default,
+            'admin'. Cannot be a MySQL reserved word.
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 16
+          default: admin
+        version:
+          type: string
+          title: MySQL Version
+          description: Version of the MySQL database engine
+          enum:
+          - '5.7'
+          - '8.0'
+          - '8.4'
+          default: '8.4'
+        database_name:
+          type: string
+          title: Database Name
+          description: Initial database to create
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 64
+          default: myapp
+    sizing:
+      type: object
+      title: Sizing & Performance
+      x-ui-order:
+      - instance_class
+      - allocated_storage
+      - max_allocated_storage
+      - storage_type
+      - read_replica_count
+      - multi_az
+      properties:
+        instance_class:
+          type: string
+          title: Instance Class
+          description: RDS instance class for performance and capacity
+          enum:
+          - db.t3.micro
+          - db.t3.small
+          - db.t3.medium
+          - db.t3.large
+          - db.t4g.micro
+          - db.t4g.small
+          - db.t4g.medium
+          - db.t4g.large
+          - db.m5.large
+          - db.m5.xlarge
+          - db.m5.2xlarge
+          default: db.t3.small
+        allocated_storage:
+          type: number
+          title: Allocated Storage (GB)
+          description: Initial storage allocation in GB
+          minimum: 20
+          maximum: 65536
+          default: 100
+        max_allocated_storage:
+          type: number
+          title: Max Storage (GB)
+          description: Maximum storage for autoscaling (0 to disable)
+          minimum: 0
+          maximum: 65536
+          default: 1000
+        storage_type:
+          type: string
+          title: Storage Type
+          description: Storage type for the database
+          enum:
+          - gp2
+          - gp3
+          - io1
+          - io2
+          default: gp3
+        read_replica_count:
+          type: number
+          title: Read Replica Count
+          description: Number of read replicas to create
+          minimum: 0
+          maximum: 5
+          default: 0
+        multi_az:
+          type: boolean
+          title: Multi-AZ
+          description: Deploy a standby in a second availability zone. Roughly doubles
+            instance and storage cost. Disable to match a single-AZ source instance.
+          default: true
+    security_config:
+      type: object
+      title: Security & Protection
+      x-ui-order:
+      - kms_key_arn
+      - deletion_protection
+      - allowed_cidrs
+      properties:
+        kms_key_arn:
+          type: string
+          title: KMS Key ARN
+          description: Customer-managed KMS key for storage encryption. Leave blank
+            and the module creates a dedicated key for this database. Supply a shared
+            key ARN to mirror a single-key estate. Encryption is always on either way.
+          pattern: ^arn:aws:kms:[a-z0-9-]+:[0-9]{12}:key/[a-zA-Z0-9-]+$
+          x-ui-placeholder: arn:aws:kms:ap-south-1:123456789012:key/mrk-abc123
+        deletion_protection:
+          type: boolean
+          title: Enable Deletion Protection
+          description: Blocks deletion through the AWS console, CLI and API. Distinct
+            from Terraform lifecycle protection.
+          default: true
+        allowed_cidrs:
+          type: array
+          title: Additional Ingress CIDRs
+          description: Extra CIDRs permitted on the database port, on top of the VPC
+            CIDR which is always allowed. Open CIDRs are rejected.
+          items:
+            type: string
+          default: []
+    parameter_group:
+      type: object
+      title: Parameter Group
+      x-ui-order:
+      - parameters
+      properties:
+        parameters:
+          type: object
+          title: Parameters
+          description: Engine parameters. Supply any and the module creates a dedicated
+            parameter group; leave empty to use the RDS engine default. Values are
+            strings, e.g. max_connections '500'.
+          x-ui-yaml-editor: true
+          patternProperties:
+            ^[a-zA-Z0-9_.]+$:
+              type: string
+          default: {}
+    backup_config:
+      type: object
+      title: Backup & Maintenance
+      x-ui-order:
+      - retention_days
+      - backup_window
+      - maintenance_window
+      properties:
+        retention_days:
+          type: number
+          title: Backup Retention (days)
+          description: Automated backup retention. 0 disables automated backups.
+          minimum: 0
+          maximum: 35
+          default: 7
+        backup_window:
+          type: string
+          title: Backup Window
+          description: Daily backup window in UTC, hh:mm-hh:mm.
+          pattern: ^[0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2}$
+          default: 03:00-04:00
+        maintenance_window:
+          type: string
+          title: Maintenance Window
+          description: Weekly maintenance window in UTC, ddd:hh:mm-ddd:hh:mm.
+          default: sun:04:00-sun:05:00
+    network_config:
+      type: object
+      title: Network Placement
+      x-ui-order:
+      - use_database_subnets
+      properties:
+        use_database_subnets:
+          type: boolean
+          title: Use Dedicated Database Subnets
+          description: Place the database in the network's isolated database subnets,
+            which carry no default route. Disable to use the private subnets shared
+            with cluster nodes.
+          default: true
+    restore_config:
+      type: object
+      title: Restore Operations
+      x-ui-overrides-only: true
+      x-ui-order:
+      - restore_from_backup
+      - source_db_instance_identifier
+      - restore_master_username
+      - restore_master_password
+      properties:
+        restore_from_backup:
+          type: boolean
+          title: Restore from Backup
+          description: Restore database from existing backup or snapshot
+          default: false
+        source_db_instance_identifier:
+          type: string
+          title: Source DB Instance
+          description: Source database instance identifier for restore
+          x-ui-visible-if:
+            field: spec.restore_config.restore_from_backup
+            values:
+            - true
+        restore_master_username:
+          type: string
+          title: Restore Master Username
+          description: Master username for restored database (required for restore
+            operations)
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 16
+          x-ui-visible-if:
+            field: spec.restore_config.restore_from_backup
+            values:
+            - true
+        restore_master_password:
+          type: string
+          title: Restore Master Password
+          description: Master password for restored database (required for restore
+            operations)
+          minLength: 8
+          maxLength: 128
+          pattern: ^[a-zA-Z0-9!@#$%^&*()_+=\-]{8,128}$
+          x-ui-error-message: "Password must be 8-128 chars with valid characters."
+          x-ui-visible-if:
+            field: spec.restore_config.restore_from_backup
+            values:
+            - true
+    imports:
+      type: object
+      title: Import Existing Resources
+      x-ui-overrides-only: true
+      x-ui-order:
+      - import_existing
+      - db_instance_identifier
+      - db_subnet_group_name
+      properties:
+        import_existing:
+          type: boolean
+          title: Import Existing Resources
+          description: Enable to import existing AWS RDS resources
+          default: false
+        db_instance_identifier:
+          type: string
+          title: DB Instance Identifier
+          description: Identifier of existing RDS instance to import
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+        db_subnet_group_name:
+          type: string
+          title: DB Subnet Group Name
+          description: Name of existing DB subnet group to import
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+        security_group_id:
+          type: string
+          title: Security Group ID
+          description: ID of existing security group to import
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+        master_password:
+          type: string
+          title: Master Password
+          description: Master password for the imported resource (8+ characters)
+          minLength: 8
+          pattern: ^[a-zA-Z0-9!@#$%^&*()_+=\-]{8,}$
+          x-ui-error-message: "Password must be 8+ chars with valid characters."
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+  required:
+  - version_config
+imports:
+- name: db_instance_identifier
+  resource_address: aws_db_instance.mysql
+  required: true
+- name: db_subnet_group_name
+  resource_address: aws_db_subnet_group.mysql
+  required: false
+- name: security_group_id
+  resource_address: aws_security_group.mysql
+  required: false
+- name: master_password
+  resource_address: random_password.master_password[0]
+  required: true
+inputs:
+  aws_provider:
+    type: '@facets/aws_cloud_account'
+    optional: false
+    displayName: AWS Cloud Account
+    description: AWS cloud account configuration for provider setup
+    providers:
+    - aws
+  vpc_details:
+    type: '@facets/aws-vpc-details'
+    optional: false
+    displayName: VPC Network Details
+    description: VPC configuration for database networking
+outputs:
+  default:
+    type: '@facets/mysql'
+    title: MySQL RDS Instance
+iac:
+  validated_files:
+  - main.tf
+  - variables.tf
+  - locals.tf
+sample:
+  kind: mysql
+  flavor: aws-rds
+  version: '1.1'
+  disabled: true
+  spec:
+    version_config:
+      version: '8.4'
+      database_name: myapp
+    sizing:
+      instance_class: db.t3.small
+      allocated_storage: 100
+      max_allocated_storage: 1000
+      storage_type: gp3
+      read_replica_count: 0
+    restore_config:
+      restore_from_backup: false

--- a/modules/datastore/mysql/aws-rds-blackbuck/1.0/locals.tf
+++ b/modules/datastore/mysql/aws-rds-blackbuck/1.0/locals.tf
@@ -1,0 +1,96 @@
+# Local values for computed attributes and password management
+locals {
+  # Import detection flags
+  import_enabled           = lookup(var.instance.spec, "imports", null) != null ? lookup(var.instance.spec.imports, "import_existing", false) : false
+  is_db_instance_import    = local.import_enabled && lookup(var.instance.spec.imports, "db_instance_identifier", null) != null
+  is_subnet_group_import   = local.import_enabled && lookup(var.instance.spec.imports, "db_subnet_group_name", null) != null
+  is_security_group_import = local.import_enabled && lookup(var.instance.spec.imports, "security_group_id", null) != null
+
+  # Resource identifiers - use imported values if available, otherwise generate new names
+  db_identifier       = local.is_db_instance_import ? var.instance.spec.imports.db_instance_identifier : "${var.instance_name}-${var.environment.unique_name}"
+  subnet_group_name   = local.is_subnet_group_import ? var.instance.spec.imports.db_subnet_group_name : "${var.instance_name}-${var.environment.unique_name}-subnet-group"
+  security_group_name = "${var.instance_name}-${var.environment.unique_name}-sg"
+  security_group_id   = local.is_security_group_import ? var.instance.spec.imports.security_group_id : null
+
+  # Add suffix to replica names when importing to avoid conflicts with existing replicas
+  # This ensures new Terraform-managed replicas don't conflict with pre-existing unmanaged replicas
+  # Reserve 15 characters for suffix: "-imp-replica-5" (worst case scenario)
+  # This leaves 48 characters for the base identifier when importing, 52 when not importing
+
+  # Helper to truncate without ending on hyphen
+  base_for_import = substr(local.db_identifier, 0, 44)
+  base_cleaned    = substr(local.base_for_import, -1, 1) == "-" ? substr(local.base_for_import, 0, 43) : local.base_for_import
+
+  replica_identifier_base = local.is_db_instance_import ? substr("${local.base_cleaned}imp", 0, 47) : substr(local.db_identifier, 0, 52)
+
+  # Database configuration
+  is_restore_operation = var.instance.spec.restore_config.restore_from_backup
+
+  # When importing, username and password should be same as the original to avoid overriding existing values
+  master_username = local.is_restore_operation ? var.instance.spec.restore_config.restore_master_username : var.instance.spec.version_config.master_username
+  master_password = local.is_restore_operation ? var.instance.spec.restore_config.restore_master_password : random_password.master_password[0].result
+
+  # Database name - should be same when importing
+  database_name = var.instance.spec.version_config.database_name
+
+  # Max allocated storage (0 means disabled)
+  max_allocated_storage = var.instance.spec.sizing.max_allocated_storage > 0 ? var.instance.spec.sizing.max_allocated_storage : null
+
+  # Port mapping for MySQL
+  mysql_port = 3306
+
+  # Performance Insights support - only supported on certain instance classes.
+  # Confirmed against describe-orderable-db-instance-options for mysql 8.4.9 in ap-south-1:
+  # SupportsPerformanceInsights=false for db.t3.micro, db.t3.small, db.t4g.micro and db.t4g.small.
+  # The t4g entries matter as much as the t3 ones - enabling PI on an unsupported class fails at apply.
+  performance_insights_supported = !contains(["db.t3.micro", "db.t3.small", "db.t4g.micro", "db.t4g.small"], var.instance.spec.sizing.instance_class)
+
+  # Enhanced Security Group Logic
+  # Detect if security group exists by name (when not explicitly importing)
+  # This logic is evaluated after the data source runs
+  sg_exists_by_name = !local.is_security_group_import && length(try(data.aws_security_groups.existing_sg[0].ids, [])) > 0
+
+  # Determine if we should create a new security group
+  should_create_security_group = !local.is_security_group_import && !local.sg_exists_by_name
+
+  # Security group source for logging/transparency
+  sg_source = local.is_security_group_import ? "imported" : (local.sg_exists_by_name ? "existing" : "created")
+
+  # ---- migration-parity additions (aws-rds-blackbuck) ----
+  sec   = lookup(var.instance.spec, "security_config", {})
+  pgrp  = lookup(var.instance.spec, "parameter_group", {})
+  bkp   = lookup(var.instance.spec, "backup_config", {})
+  netcf = lookup(var.instance.spec, "network_config", {})
+
+  # KMS: use the supplied key, else the one this module creates.
+  kms_key_arn_input = lookup(local.sec, "kms_key_arn", null)
+  create_kms_key    = local.kms_key_arn_input == null || local.kms_key_arn_input == ""
+  kms_key_arn       = local.create_kms_key ? aws_kms_key.mysql[0].arn : local.kms_key_arn_input
+
+  # Parameter group: only create one when parameters were actually supplied.
+  db_parameters          = lookup(local.pgrp, "parameters", {})
+  create_parameter_grp   = length(local.db_parameters) > 0
+  parameter_group_name   = local.create_parameter_grp ? aws_db_parameter_group.mysql[0].name : null
+  parameter_group_family = "mysql${var.instance.spec.version_config.version}"
+
+  # Backup / maintenance
+  backup_retention_period = lookup(local.bkp, "retention_days", 7)
+  backup_window           = lookup(local.bkp, "backup_window", "03:00-04:00")
+  maintenance_window      = lookup(local.bkp, "maintenance_window", "sun:04:00-sun:05:00")
+
+  # Subnet placement. Fall back to private subnets when the network module did not
+  # publish database subnets, so the module still works against an older network.
+  use_db_subnets       = lookup(local.netcf, "use_database_subnets", true)
+  published_db_subnets = try(var.inputs.vpc_details.attributes.database_subnet_ids, [])
+  db_subnet_ids = (local.use_db_subnets && length(local.published_db_subnets) > 0
+    ? local.published_db_subnets
+  : var.inputs.vpc_details.attributes.private_subnet_ids)
+
+  # Ingress: VPC CIDR is always permitted; extras are additive and validated.
+  allowed_cidrs = distinct(concat(
+    [var.inputs.vpc_details.attributes.vpc_cidr_block],
+    lookup(local.sec, "allowed_cidrs", [])
+  ))
+
+  deletion_protection = lookup(local.sec, "deletion_protection", true)
+}

--- a/modules/datastore/mysql/aws-rds-blackbuck/1.0/main.tf
+++ b/modules/datastore/mysql/aws-rds-blackbuck/1.0/main.tf
@@ -1,0 +1,339 @@
+# Generate random password for master user (only if not restoring and not importing)
+resource "random_password" "master_password" {
+  count            = local.is_restore_operation ? 0 : 1
+  length           = 16
+  special          = true
+  upper            = true
+  lower            = true
+  numeric          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+
+  lifecycle {
+    ignore_changes = [
+      length,
+      override_special,
+    ]
+  }
+}
+
+# Create DB subnet group (only if not importing) - handle existing gracefully
+# ---- migration-parity resources (aws-rds-blackbuck) ----
+
+# Dedicated CMK, created only when no key ARN was supplied. Pass a shared ARN on
+# every database to reproduce a single-key estate instead.
+resource "aws_kms_key" "mysql" {
+  count = local.create_kms_key ? 1 : 0
+
+  description             = "CMK for RDS MySQL ${local.db_identifier}"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+
+  tags = merge(var.environment.cloud_tags, {
+    Name   = "${local.db_identifier}-kms"
+    Module = "mysql"
+    Flavor = "aws-rds-blackbuck"
+  })
+}
+
+resource "aws_kms_alias" "mysql" {
+  count = local.create_kms_key ? 1 : 0
+
+  name          = "alias/${substr(local.db_identifier, 0, 200)}-rds"
+  target_key_id = aws_kms_key.mysql[0].key_id
+}
+
+# Parameter group, created only when parameters were supplied. Without it RDS
+# applies default.mysql<major>, which is what the standard flavor always does.
+resource "aws_db_parameter_group" "mysql" {
+  count = local.create_parameter_grp ? 1 : 0
+
+  name   = substr("${local.db_identifier}-pg", 0, 255)
+  family = local.parameter_group_family
+
+  dynamic "parameter" {
+    for_each = local.db_parameters
+    content {
+      name  = parameter.key
+      value = parameter.value
+      # static parameters need a reboot; RDS rejects immediate application
+      apply_method = "pending-reboot"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(var.environment.cloud_tags, {
+    Name   = "${local.db_identifier}-pg"
+    Module = "mysql"
+    Flavor = "aws-rds-blackbuck"
+  })
+}
+
+resource "aws_db_subnet_group" "mysql" {
+  count      = local.is_subnet_group_import ? 0 : 1
+  name       = local.subnet_group_name
+  subnet_ids = local.db_subnet_ids
+
+  tags = merge(var.environment.cloud_tags, {
+    Name   = local.subnet_group_name
+    Module = "mysql"
+    Flavor = "aws-rds"
+  })
+
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes = [
+      name,      # Ignore name changes for imported resources
+      subnet_ids # Ignore changes to subnet IDs for imported resources
+    ]
+  }
+}
+
+# Data source to fetch imported subnet group
+data "aws_db_subnet_group" "imported" {
+  count = local.is_subnet_group_import ? 1 : 0
+  name  = local.subnet_group_name
+}
+
+# Data source to check if security group already exists by name
+data "aws_security_groups" "existing_sg" {
+  count = !local.is_security_group_import ? 1 : 0
+
+  filter {
+    name   = "group-name"
+    values = [local.security_group_name]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [var.inputs.vpc_details.attributes.vpc_id]
+  }
+}
+
+# Create security group for MySQL (only if not importing AND doesn't already exist)
+resource "aws_security_group" "mysql" {
+  count       = local.should_create_security_group ? 1 : 0
+  name        = local.security_group_name
+  description = "Security group for MySQL RDS instance ${var.instance_name}"
+  vpc_id      = var.inputs.vpc_details.attributes.vpc_id
+
+  # Allow MySQL access from VPC
+  ingress {
+    from_port   = local.mysql_port
+    to_port     = local.mysql_port
+    protocol    = "tcp"
+    cidr_blocks = local.allowed_cidrs
+    description = "MySQL access from VPC and any explicitly allowed CIDRs"
+  }
+
+  # Allow all outbound traffic
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound traffic"
+  }
+
+  tags = merge(var.environment.cloud_tags, {
+    Name   = local.security_group_name
+    Module = "mysql"
+    Flavor = "aws-rds"
+  })
+
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes = [
+      name,        # Ignore name changes for imported resources
+      vpc_id,      # Ignore VPC changes for imported resources
+      description, # Ignore description changes for imported resources
+      ingress,     # Ignore ingress rule changes for imported resources
+      egress       # Ignore egress rule changes for imported resources
+    ]
+  }
+}
+
+# Data source to fetch imported security group
+data "aws_security_group" "imported" {
+  count = local.is_security_group_import ? 1 : 0
+  id    = local.security_group_id
+}
+
+# Local variables for resource references
+locals {
+  # Get the actual subnet group name (imported or created)
+  actual_subnet_group_name = local.is_subnet_group_import ? data.aws_db_subnet_group.imported[0].name : (length(aws_db_subnet_group.mysql) > 0 ? aws_db_subnet_group.mysql[0].name : null)
+
+  # Get the actual security group ID from all sources (imported, existing by name, or created)
+  actual_security_group_id = local.is_security_group_import ? data.aws_security_group.imported[0].id : (
+    local.sg_exists_by_name ? data.aws_security_groups.existing_sg[0].ids[0] :
+    (length(aws_security_group.mysql) > 0 ? aws_security_group.mysql[0].id : null)
+  )
+
+  # Always use the main mysql resource identifier for read replicas
+  mysql_instance_identifier = aws_db_instance.mysql.identifier
+}
+
+# Create the MySQL RDS instance (handles new, imported, and restored instances)
+resource "aws_db_instance" "mysql" {
+  # Removed count parameter to allow imports - resource always exists
+
+  # Basic configuration
+  identifier     = local.db_identifier
+  engine         = "mysql"
+  engine_version = var.instance.spec.version_config.version
+
+  # Instance configuration
+  instance_class        = var.instance.spec.sizing.instance_class
+  allocated_storage     = var.instance.spec.sizing.allocated_storage
+  max_allocated_storage = local.max_allocated_storage
+  storage_type          = var.instance.spec.sizing.storage_type
+  storage_encrypted     = true # Always enabled for security
+  kms_key_id            = local.kms_key_arn
+
+  # Database configuration - use conditional values for importing
+  db_name  = local.database_name
+  username = local.master_username
+  password = local.master_password
+  port     = local.mysql_port
+
+  # Network configuration
+  db_subnet_group_name   = local.actual_subnet_group_name
+  vpc_security_group_ids = [local.actual_security_group_id]
+  publicly_accessible    = false # Always private for security
+
+  # High availability and backup configuration (hardcoded for security)
+  multi_az                = var.instance.spec.sizing.multi_az
+  backup_retention_period = local.backup_retention_period
+  backup_window           = local.backup_window
+  maintenance_window      = local.maintenance_window
+  parameter_group_name    = local.parameter_group_name
+
+  # Performance and monitoring (hardcoded for production readiness)
+  performance_insights_enabled    = local.performance_insights_supported
+  monitoring_interval             = 0 # Disabled to avoid IAM role requirement
+  enabled_cloudwatch_logs_exports = ["error", "general", "slowquery"]
+
+  deletion_protection       = local.deletion_protection
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${local.db_identifier}-final-snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
+
+  # Restore configuration - only set when restoring from backup
+  dynamic "restore_to_point_in_time" {
+    for_each = local.is_restore_operation && !local.is_db_instance_import ? [1] : []
+    content {
+      source_db_instance_identifier = var.instance.spec.restore_config.source_db_instance_identifier
+      use_latest_restorable_time    = true
+    }
+  }
+
+  # Lifecycle management
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes = [
+      identifier,                # Ignore identifier changes for imported resources
+      password,                  # Password might be managed externally when importing
+      username,                  # Username might be different when importing
+      db_name,                   # Database name might be different when importing
+      final_snapshot_identifier, # Timestamp will always change
+      db_subnet_group_name,      # Ignore subnet group name changes for imported resources
+      vpc_security_group_ids,    # Ignore security group changes for imported resources
+      engine_version,            # Prevent forced upgrades on imported instances
+      storage_type,              # Storage type changes require recreation
+      storage_encrypted          # Encryption cannot be changed after creation
+      # kms_key_id deliberately NOT ignored here: this flavor manages the key, and
+      # silently swallowing a changed ARN would hide a real (replacement) change.
+    ]
+  }
+
+  tags = merge(var.environment.cloud_tags, {
+    Name   = local.db_identifier
+    Module = "mysql"
+    Flavor = "aws-rds"
+  })
+}
+
+
+# Create read replicas if requested (works with both created and imported instances)
+resource "aws_db_instance" "read_replicas" {
+  count = var.instance.spec.sizing.read_replica_count
+
+  # Basic configuration
+  # Use replica_identifier_base which adds "imp" suffix when importing to avoid conflicts
+  identifier = "${local.replica_identifier_base}-replica-${count.index + 1}"
+  # IMPORTANT: Use the identifier, not the id, for replication source
+  replicate_source_db = local.mysql_instance_identifier
+
+  # Instance configuration (same as master for consistency)
+  instance_class = var.instance.spec.sizing.instance_class
+  storage_type   = var.instance.spec.sizing.storage_type
+
+  # Network configuration (same security group)
+  vpc_security_group_ids = [local.actual_security_group_id]
+  publicly_accessible    = false
+
+  # Performance monitoring
+  performance_insights_enabled = local.performance_insights_supported
+  monitoring_interval          = 0 # Disabled to avoid IAM role requirement
+
+  # No backups for read replicas
+  backup_retention_period = 0
+
+  # Deletion protection disabled for testing
+  deletion_protection = false
+  skip_final_snapshot = true # Read replicas don't need final snapshots
+
+  # Lifecycle management
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes = [
+      identifier,            # Ignore identifier changes for imported resources
+      replicate_source_db,   # Ignore source DB changes for flexibility
+      vpc_security_group_ids # Ignore security group changes for imported resources
+    ]
+  }
+
+  tags = merge(var.environment.cloud_tags, {
+    Name   = "${local.replica_identifier_base}-replica-${count.index + 1}"
+    Module = "mysql"
+    Flavor = "aws-rds"
+    Role   = "read-replica"
+  })
+}
+
+# Import blocks for Terraform to manage existing resources
+# These are handled by the Facets platform based on the imports section in facets.yaml
+
+# For imported DB instances, we need to handle certain attributes differently
+# The ignore_changes in lifecycle blocks ensure that imported resources
+# don't get recreated due to differences in configuration
+
+# Important: When importing resources, the following attributes are ignored:
+# - Resource identifiers/names (to prevent recreation)
+# - Network configurations (subnet groups, security groups)
+# - Ingress/egress rules for security groups
+# - Engine version (to prevent forced upgrades)
+# - Storage type and encryption (cannot be changed without recreation)
+# These can genuinely only be changed by recreating the resources
+
+# When importing existing instances, read replicas get "imp" suffix to avoid conflicts
+# with existing unmanaged replicas. This allows gradual migration to Terraform management.
+
+# Password management - using random password generation only for new instances
+# For imported instances, passwords are managed externally
+# The password is stored in Terraform state and accessible via output interfaces
+# For production use, consider external secret management solutions
+
+# Enhanced Security Group Handling:
+# The module now supports three security group scenarios:
+# 1. EXPLICIT IMPORT: User provides security_group_id in imports section
+# 2. EXISTING BY NAME: Security group with same name already exists in VPC 
+# 3. CREATE NEW: No existing security group found, creates new one
+#
+# This prevents the "security group already exists" error by:
+# - Using data source to check for existing security groups by name
+# - Only creating new security group when none exists and not explicitly importing
+# - Transparently using existing security groups when found
+# - Providing sg_source output to show which approach was used

--- a/modules/datastore/mysql/aws-rds-blackbuck/1.0/outputs.tf
+++ b/modules/datastore/mysql/aws-rds-blackbuck/1.0/outputs.tf
@@ -1,0 +1,60 @@
+locals {
+  output_attributes = {}
+  output_interfaces = {
+    reader = {
+      host     = length(aws_db_instance.read_replicas) > 0 ? aws_db_instance.read_replicas[0].address : aws_db_instance.mysql.address
+      username = aws_db_instance.mysql.username
+      port     = aws_db_instance.mysql.port
+      password = local.master_password
+      database = aws_db_instance.mysql.db_name
+      connection_string = local.is_db_instance_import ? (
+        length(aws_db_instance.read_replicas) > 0 ?
+        format(
+          "mysql://%s:%s@%s:%d/%s",
+          aws_db_instance.mysql.username,
+          local.master_password,
+          aws_db_instance.read_replicas[0].address,
+          aws_db_instance.read_replicas[0].port,
+          aws_db_instance.mysql.db_name
+        ) :
+        format(
+          "mysql://%s:%s@%s:%d/%s",
+          aws_db_instance.mysql.username,
+          local.master_password,
+          aws_db_instance.mysql.address,
+          aws_db_instance.mysql.port,
+          aws_db_instance.mysql.db_name
+        )
+        ) : (
+        length(aws_db_instance.read_replicas) > 0 ?
+        format(
+          "mysql://%s:%s@%s:%d/%s",
+          aws_db_instance.mysql.username,
+          local.master_password,
+          aws_db_instance.read_replicas[0].address,
+          aws_db_instance.read_replicas[0].port,
+          aws_db_instance.mysql.db_name
+        ) :
+        format(
+          "mysql://%s:%s@%s:%d/%s",
+          aws_db_instance.mysql.username,
+          local.master_password,
+          aws_db_instance.mysql.address,
+          aws_db_instance.mysql.port,
+          aws_db_instance.mysql.db_name
+        )
+      )
+      secrets = ["password", "connection_string"]
+    }
+
+    writer = {
+      host              = aws_db_instance.mysql.address
+      port              = aws_db_instance.mysql.port
+      username          = aws_db_instance.mysql.username
+      password          = local.master_password
+      database          = aws_db_instance.mysql.db_name
+      connection_string = "mysql://${aws_db_instance.mysql.username}:${local.master_password}@${aws_db_instance.mysql.address}:${aws_db_instance.mysql.port}/${aws_db_instance.mysql.db_name}"
+      secrets           = ["password", "connection_string"]
+    }
+  }
+}

--- a/modules/datastore/mysql/aws-rds-blackbuck/1.0/variables.tf
+++ b/modules/datastore/mysql/aws-rds-blackbuck/1.0/variables.tf
@@ -1,0 +1,149 @@
+variable "instance" {
+  description = "Managed MySQL database instance on AWS RDS with high availability, automated backups, and read replicas"
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+    spec = object({
+      version_config = object({
+        version       = string
+        database_name = string
+        # Optional: falls back to "admin", which is what locals.tf used unconditionally
+        # before this attribute was reachable from the spec.
+        master_username = optional(string, "admin")
+      })
+      sizing = object({
+        instance_class        = string
+        allocated_storage     = number
+        max_allocated_storage = number
+        storage_type          = string
+        read_replica_count    = number
+        # Optional: defaults to true, which is what main.tf hardcoded before this
+        # attribute existed. Set false to match a single-AZ source instance.
+        multi_az = optional(bool, true)
+      })
+      security_config = optional(object({
+        kms_key_arn         = optional(string)
+        deletion_protection = optional(bool, true)
+        allowed_cidrs       = optional(list(string), [])
+      }), {})
+      parameter_group = optional(object({
+        parameters = optional(map(string), {})
+      }), {})
+      backup_config = optional(object({
+        retention_days     = optional(number, 7)
+        backup_window      = optional(string, "03:00-04:00")
+        maintenance_window = optional(string, "sun:04:00-sun:05:00")
+      }), {})
+      network_config = optional(object({
+        use_database_subnets = optional(bool, true)
+      }), {})
+      restore_config = optional(object({
+        restore_from_backup           = bool
+        source_db_instance_identifier = optional(string)
+        restore_master_username       = optional(string)
+        restore_master_password       = optional(string)
+      }), { restore_from_backup = false })
+      imports = optional(object({
+        import_existing        = optional(bool, false)
+        db_instance_identifier = optional(string)
+        db_subnet_group_name   = optional(string)
+        security_group_id      = optional(string)
+        master_password        = optional(string)
+      }))
+    })
+  })
+
+  validation {
+    condition     = contains(["5.7", "8.0", "8.4"], var.instance.spec.version_config.version)
+    error_message = "MySQL version must be one of: 5.7, 8.0, 8.4"
+  }
+
+  validation {
+    condition     = contains(["db.t3.micro", "db.t3.small", "db.t3.medium", "db.t3.large", "db.t4g.micro", "db.t4g.small", "db.t4g.medium", "db.t4g.large", "db.m5.large", "db.m5.xlarge", "db.m5.2xlarge"], var.instance.spec.sizing.instance_class)
+    error_message = "Instance class must be a valid RDS instance type"
+  }
+
+  validation {
+    condition     = var.instance.spec.sizing.allocated_storage >= 20 && var.instance.spec.sizing.allocated_storage <= 65536
+    error_message = "Allocated storage must be between 20 and 65536 GB"
+  }
+
+  validation {
+    condition     = var.instance.spec.sizing.max_allocated_storage >= 0 && var.instance.spec.sizing.max_allocated_storage <= 65536
+    error_message = "Max allocated storage must be between 0 and 65536 GB"
+  }
+
+  validation {
+    condition     = contains(["gp2", "gp3", "io1", "io2"], var.instance.spec.sizing.storage_type)
+    error_message = "Storage type must be one of: gp2, gp3, io1, io2"
+  }
+
+  validation {
+    condition     = var.instance.spec.sizing.read_replica_count >= 0 && var.instance.spec.sizing.read_replica_count <= 5
+    error_message = "Read replica count must be between 0 and 5"
+  }
+
+  validation {
+    condition     = length(var.instance.spec.version_config.database_name) >= 1 && length(var.instance.spec.version_config.database_name) <= 64
+    error_message = "Database name must be between 1 and 64 characters"
+  }
+
+  validation {
+    condition     = length(var.instance.spec.version_config.master_username) >= 1 && length(var.instance.spec.version_config.master_username) <= 16
+    error_message = "Master username must be between 1 and 16 characters"
+  }
+
+  validation {
+    condition = alltrue([
+      for c in lookup(lookup(var.instance.spec, "security_config", {}), "allowed_cidrs", []) :
+      !contains(["0.0.0.0/0", "::/0"], c)
+    ])
+    error_message = "allowed_cidrs must not contain an open CIDR (0.0.0.0/0 or ::/0). Grant the specific ranges that need access."
+  }
+
+  validation {
+    condition = alltrue([
+      for c in lookup(lookup(var.instance.spec, "security_config", {}), "allowed_cidrs", []) :
+      can(cidrnetmask(c))
+    ])
+    error_message = "Every entry in allowed_cidrs must be a valid IPv4 CIDR."
+  }
+}
+
+variable "instance_name" {
+  description = "The architectural name for the resource as added in the Facets blueprint designer."
+  type        = string
+}
+
+variable "environment" {
+  description = "An object containing details about the environment."
+  type = object({
+    name        = string
+    unique_name = string
+    cloud_tags  = map(string)
+  })
+}
+
+variable "inputs" {
+  description = "A map of inputs requested by the module developer."
+  type = object({
+    aws_provider = object({
+      attributes = object({
+        aws_iam_role = string
+        session_name = string
+        external_id  = string
+        aws_region   = string
+      })
+    })
+    vpc_details = object({
+      attributes = object({
+        vpc_id             = string
+        private_subnet_ids = list(string)
+        public_subnet_ids  = list(string)
+        availability_zones = list(string)
+        vpc_cidr_block     = string
+      })
+    })
+  })
+}

--- a/modules/datastore/postgres/aws-rds-blackbuck/1.0/README.md
+++ b/modules/datastore/postgres/aws-rds-blackbuck/1.0/README.md
@@ -1,0 +1,126 @@
+# PostgreSQL RDS Module
+
+![Version](https://img.shields.io/badge/version-1.0-blue) ![Cloud](https://img.shields.io/badge/cloud-AWS-orange)
+
+## Overview
+
+This module provisions a managed PostgreSQL database using Amazon RDS with enterprise-grade security defaults and operational best practices. It provides a developer-friendly interface while maintaining production-ready configurations for encryption, backup, and high availability.
+
+## Environment as Dimension
+
+This module is environment-aware and adapts configurations based on the deployment environment:
+
+- **Resource Naming**: Incorporates `var.environment.unique_name` to ensure unique resource identifiers across environments
+- **Tagging Strategy**: Applies environment-specific tags via `var.environment.cloud_tags` for consistent resource organization
+- **Network Isolation**: Deploys within environment-specific VPC infrastructure provided through inputs
+
+Environment-specific variations are handled through the infrastructure inputs rather than direct environment variables, maintaining consistency while allowing environment-appropriate networking and access controls.
+
+## Resources Created
+
+- **RDS PostgreSQL Instance** - Primary database instance with multi-AZ deployment for high availability
+- **Read Replicas** - Optional read-only replicas for improved read performance and load distribution
+- **DB Subnet Group** - Private subnet configuration ensuring database isolation from public networks  
+- **Security Group** - Restrictive network access controls allowing database connections only from within the VPC
+- **Random Credentials** - Secure master username and password generation when not restoring from backup
+
+## Security Considerations
+
+This module implements security-first defaults that cannot be disabled:
+
+- **Encryption at Rest**: All database storage is encrypted using AWS-managed keys
+- **Network Isolation**: Database instances are deployed in private subnets with no public access
+- **Access Controls**: Security groups restrict database access to VPC CIDR blocks only
+- **Backup Security**: Automated backups with 7-day retention and encrypted snapshots
+- **Deletion Protection**: Prevents accidental database deletion in production environments
+- **Performance Monitoring**: Performance Insights enabled for security event monitoring
+
+Users should ensure proper IAM policies and VPC configurations are in place to maintain the security posture established by this module.
+
+## Import Existing Infrastructure
+
+This module supports importing existing AWS RDS PostgreSQL instances and their associated resources into Terraform management.
+
+### Supported Import Resources
+
+- **RDS Instance**: Import existing primary or read replica instances
+- **DB Subnet Group**: Import existing subnet group configurations
+- **Security Group**: Import existing security group rules
+
+### Import Configuration
+
+To import existing resources, provide the following fields in the `imports` section:
+
+```yaml
+spec:
+  imports:
+    db_instance_identifier: "my-existing-rds-instance"
+    subnet_group_name: "my-existing-subnet-group"
+    security_group_id: "sg-0123456789abcdef0"
+```
+
+### Import Workflow
+
+1. **Configure Import Fields**: Set the appropriate identifiers in the module configuration
+2. **Run Terraform Import**: Execute import commands for each resource:
+   ```bash
+   terraform import module.postgres.aws_db_instance.postgres my-existing-rds-instance
+   terraform import module.postgres.aws_db_subnet_group.postgres[0] my-existing-subnet-group
+   terraform import module.postgres.aws_security_group.postgres[0] sg-0123456789abcdef0
+   ```
+3. **Verify State**: Run `terraform plan` to ensure imported resources match configuration
+
+### Important Limitations
+
+#### Read Replica Handling
+
+When importing a primary instance that has existing read replicas:
+
+- **Only the primary instance is imported** into Terraform state
+- **Pre-existing read replicas remain unmanaged** by Terraform
+- **New read replicas** are created based on `read_replica_count` configuration with an `-imp` suffix to avoid naming conflicts
+- **Existing unmanaged replicas** continue to exist in AWS but outside Terraform control
+- **Example**: If existing replica is `mydb-env-replica-1`, new Terraform-managed replica will be `mydb-env-imp-replica-1`
+- **Identifier length**: Automatically truncated to stay within AWS 63-character limit, avoiding consecutive hyphens
+
+#### Destroy Behavior with Existing Replicas
+
+**Critical**: If you import a primary instance that has pre-existing read replicas and later attempt to destroy it:
+
+1. **Terraform-managed resources** (new replicas, security groups) will be destroyed successfully
+2. **Primary instance deletion will FAIL** with an error like:
+   - `InvalidDBInstanceState: Cannot delete DB instance because it has read replicas`
+   - AWS prevents deletion of primary instances with active read replicas
+
+#### Recommended Destroy Workflow
+
+Before running `terraform destroy` on an imported primary instance:
+
+1. **Identify unmanaged replicas** using AWS Console or CLI:
+   ```bash
+   aws rds describe-db-instances --query "DBInstances[?ReplicationSourceDBInstanceIdentifier=='your-primary-instance-id'].DBInstanceIdentifier"
+   ```
+
+2. **Handle existing replicas** (choose one):
+   - **Option A**: Manually delete unmanaged replicas first
+   - **Option B**: Promote replicas to standalone instances
+   - **Option C**: Use AWS Console to force-delete primary (promotes replicas automatically)
+
+3. **Run Terraform destroy** after handling unmanaged replicas
+
+#### Password Management for Imported Instances
+
+- **Passwords are not retrievable** from imported instances
+- **Connection strings** in outputs will not include passwords for imported resources
+- **Manual password management** required for imported instances
+- **Password field** shows placeholder: `IMPORTED_INSTANCE_PASSWORD_NOT_AVAILABLE`
+
+### Best Practices for Import
+
+1. **Import one instance at a time** - Either primary or a single replica
+2. **Document existing replicas** before import for future reference
+3. **Test destroy workflow** in non-production first
+4. **Consider migration strategy** for existing replicas:
+   - Keep them unmanaged for gradual migration
+   - Or recreate them as Terraform-managed resources
+5. **Enable deletion protection** to prevent accidental deletion of imported instances

--- a/modules/datastore/postgres/aws-rds-blackbuck/1.0/facets.yaml
+++ b/modules/datastore/postgres/aws-rds-blackbuck/1.0/facets.yaml
@@ -1,0 +1,385 @@
+intent: postgres
+flavor: aws-rds-blackbuck
+version: '1.0'
+clouds:
+- aws
+description: 'MIGRATION-ONLY flavor. Reproduces an existing AWS RDS PostgreSQL estate
+  faithfully, exposing configuration the standard aws-rds flavor deliberately hides
+  (KMS key, parameter group, backup retention, security-group ingress, subnet tier,
+  storage type). It intentionally departs from datastore_module_standards.md, which
+  forbids these ops-centric fields. Use aws-rds for greenfield databases; use this
+  only to onboard a pre-existing estate.'
+intentDetails:
+  type: Datastores
+  description: AWS RDS PostgreSQL managed database service
+  displayName: PostgreSQL
+  iconUrl: https://raw.githubusercontent.com/Facets-cloud/facets-modules-redesign/main/icons/postgres.svg
+spec:
+  title: PostgreSQL RDS Database
+  description: Managed PostgreSQL database using Amazon RDS with secure defaults and
+    backup support
+  type: object
+  x-ui-order:
+  - version_config
+  - sizing
+  - security_config
+  - parameter_group
+  - backup_config
+  - network_config
+  - restore_config
+  - imports
+  properties:
+    version_config:
+      type: object
+      title: Version & Basic Configuration
+      x-ui-order:
+      - engine_version
+      - database_name
+      - master_username
+      properties:
+        master_username:
+          type: string
+          title: Master Username
+          description: Master username for the database. Leave blank to use the default,
+            'pgadmin'. Cannot be a PostgreSQL reserved word.
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 63
+          default: pgadmin
+        engine_version:
+          type: string
+          title: PostgreSQL Version
+          description: Version of the PostgreSQL database engine
+          enum:
+          - '14.21'
+          - '15.16'
+          - '16.12'
+          - '16.13'
+          - '17.8'
+          - '18.1'
+          - '18.3'
+          default: '18.1'
+        database_name:
+          type: string
+          title: Database Name
+          description: Name of the initial database to create
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 63
+          default: postgres
+      required:
+      - engine_version
+      - database_name
+    sizing:
+      type: object
+      title: Sizing & Performance
+      x-ui-order:
+      - instance_class
+      - allocated_storage
+      - storage_type
+      - max_allocated_storage
+      - read_replica_count
+      - multi_az
+      properties:
+        instance_class:
+          type: string
+          title: Instance Class
+          description: Database instance class
+          enum:
+          - db.t3.micro
+          - db.t3.small
+          - db.t3.medium
+          - db.t4g.micro
+          - db.t4g.small
+          - db.t4g.medium
+          - db.t4g.large
+          - db.m5.large
+          - db.m5.xlarge
+          default: db.t3.small
+        allocated_storage:
+          type: number
+          title: Allocated Storage (GB)
+          description: Initial storage allocation in GB
+          minimum: 20
+          maximum: 65536
+          default: 100
+        storage_type:
+          type: string
+          title: Storage Type
+          description: EBS volume type backing the database.
+          enum:
+          - gp2
+          - gp3
+          - io1
+          - io2
+          default: gp3
+        max_allocated_storage:
+          type: number
+          title: Max Storage (GB)
+          description: Storage-autoscaling ceiling. 0 disables autoscaling.
+          minimum: 0
+          maximum: 65536
+          default: 0
+        read_replica_count:
+          type: number
+          title: Read Replica Count
+          description: Number of read replicas to create
+          minimum: 0
+          maximum: 5
+          default: 0
+        multi_az:
+          type: boolean
+          title: Multi-AZ
+          description: Deploy a standby in a second availability zone. Roughly doubles
+            instance and storage cost. Disable to match a single-AZ source instance.
+          default: true
+      required:
+      - instance_class
+      - allocated_storage
+      - read_replica_count
+    security_config:
+      type: object
+      title: Security & Protection
+      x-ui-order:
+      - kms_key_arn
+      - deletion_protection
+      - allowed_cidrs
+      properties:
+        kms_key_arn:
+          type: string
+          title: KMS Key ARN
+          description: Customer-managed KMS key for storage encryption. Leave blank
+            and the module creates a dedicated key for this database. Supply a shared
+            key ARN to mirror a single-key estate. Encryption is always on either way.
+          pattern: ^arn:aws:kms:[a-z0-9-]+:[0-9]{12}:key/[a-zA-Z0-9-]+$
+          x-ui-placeholder: arn:aws:kms:ap-south-1:123456789012:key/mrk-abc123
+        allowed_cidrs:
+          type: array
+          title: Additional Ingress CIDRs
+          description: Extra CIDRs permitted on the database port, on top of the VPC
+            CIDR which is always allowed. Open CIDRs are rejected.
+          items:
+            type: string
+          default: []
+        deletion_protection:
+          type: boolean
+          title: Enable Deletion Protection
+          description: Protect database from accidental deletion (recommended for
+            production)
+          default: true
+      required:
+      - deletion_protection
+    parameter_group:
+      type: object
+      title: Parameter Group
+      x-ui-order:
+      - parameters
+      properties:
+        parameters:
+          type: object
+          title: Parameters
+          description: Engine parameters. Supply any and the module creates a dedicated
+            parameter group; leave empty to use the RDS engine default. Values are
+            strings, e.g. rds.force_ssl '0'.
+          x-ui-yaml-editor: true
+          patternProperties:
+            ^[a-zA-Z0-9_.]+$:
+              type: string
+          default: {}
+    backup_config:
+      type: object
+      title: Backup & Maintenance
+      x-ui-order:
+      - retention_days
+      - backup_window
+      - maintenance_window
+      properties:
+        retention_days:
+          type: number
+          title: Backup Retention (days)
+          description: Automated backup retention. 0 disables automated backups.
+          minimum: 0
+          maximum: 35
+          default: 7
+        backup_window:
+          type: string
+          title: Backup Window
+          description: Daily backup window in UTC, hh:mm-hh:mm.
+          pattern: ^[0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2}$
+          default: 03:00-04:00
+        maintenance_window:
+          type: string
+          title: Maintenance Window
+          description: Weekly maintenance window in UTC, ddd:hh:mm-ddd:hh:mm.
+          default: sun:04:00-sun:05:00
+    network_config:
+      type: object
+      title: Network Placement
+      x-ui-order:
+      - use_database_subnets
+      properties:
+        use_database_subnets:
+          type: boolean
+          title: Use Dedicated Database Subnets
+          description: Place the database in the network's isolated database subnets,
+            which carry no default route. Disable to use the private subnets shared
+            with cluster nodes.
+          default: true
+    restore_config:
+      type: object
+      title: Restore Operations
+      x-ui-overrides-only: true
+      x-ui-order:
+      - restore_from_backup
+      - source_db_instance_identifier
+      - master_username
+      - master_password
+      properties:
+        restore_from_backup:
+          type: boolean
+          title: Restore from Backup
+          description: Restore database from existing backup
+          default: false
+        source_db_instance_identifier:
+          type: string
+          title: Source DB Instance Identifier
+          description: Source database instance identifier for restore
+          x-ui-visible-if:
+            field: spec.restore_config.restore_from_backup
+            values:
+            - true
+        master_username:
+          type: string
+          title: Master Username
+          description: Required when restoring from backup
+          pattern: ^[a-zA-Z][a-zA-Z0-9_]*$
+          minLength: 1
+          maxLength: 63
+          x-ui-visible-if:
+            field: spec.restore_config.restore_from_backup
+        master_password:
+          type: string
+          title: Master Password
+          description: Required when restoring from backup
+          minLength: 8
+          maxLength: 128
+          pattern: ^[a-zA-Z0-9!@#$%^&*()_+=\-]{8,128}$
+          x-ui-error-message: "Password must be 8-128 chars with valid characters."
+          x-ui-visible-if:
+            field: spec.restore_config.restore_from_backup
+            values:
+            - true
+      required:
+      - restore_from_backup
+    imports:
+      type: object
+      title: Import Existing Resources
+      x-ui-overrides-only: true
+      x-ui-order:
+      - import_existing
+      - db_instance_identifier
+      - subnet_group_name
+      properties:
+        import_existing:
+          type: boolean
+          title: Import Existing Resources
+          description: Enable to import existing RDS resources
+          default: false
+        db_instance_identifier:
+          type: string
+          title: RDS Instance Identifier
+          description: Identifier of existing RDS instance to import (main or replica)
+          pattern: ^[a-zA-Z][a-zA-Z0-9-]*$
+          minLength: 1
+          maxLength: 63
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+        subnet_group_name:
+          type: string
+          title: DB Subnet Group Name
+          description: Name of existing DB subnet group (required when importing)
+          pattern: ^[a-zA-Z][a-zA-Z0-9-]*$
+          minLength: 1
+          maxLength: 255
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+        security_group_id:
+          type: string
+          title: Security Group ID
+          description: ID of existing security group (required when importing)
+          pattern: ^sg-[0-9a-fA-F]{8,17}$
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+        master_password:
+          type: string
+          title: Master Password
+          description: Master password for the imported cluster (8+ characters)
+          minLength: 8
+          pattern: ^[a-zA-Z0-9!@#$%^&*()_+=\-]{8,}$
+          x-ui-error-message: "Password must be 8+ chars with valid characters."
+          x-ui-visible-if:
+            field: spec.imports.import_existing
+            values:
+              - true
+  required:
+  - version_config
+  - sizing
+  - security_config
+imports:
+- name: db_instance_identifier
+  resource_address: aws_db_instance.postgres
+  required: false
+- name: subnet_group_name
+  resource_address: aws_db_subnet_group.postgres
+  required: false
+- name: security_group_id
+  resource_address: aws_security_group.postgres
+  required: false
+- name: master_password
+  resource_address: random_password.master_password[0]
+  required: true
+inputs:
+  aws_provider:
+    type: '@facets/aws_cloud_account'
+    optional: false
+    displayName: AWS Cloud Account
+    description: AWS cloud account configuration and provider
+    providers:
+    - aws
+  vpc_details:
+    type: '@facets/aws-vpc-details'
+    optional: false
+    displayName: VPC Infrastructure
+    description: AWS VPC infrastructure for database deployment
+outputs:
+  default:
+    type: '@facets/postgres'
+    title: PostgreSQL RDS Instance
+iac:
+  validated_files:
+  - main.tf
+  - variables.tf
+  - outputs.tf
+sample:
+  kind: postgres
+  flavor: aws-rds
+  version: '1.0'
+  disabled: true
+  spec:
+    version_config:
+      engine_version: '18.1'
+      database_name: postgres
+    sizing:
+      instance_class: db.t3.small
+      allocated_storage: 100
+      read_replica_count: 0
+    security_config:
+      deletion_protection: true
+    restore_config:
+      restore_from_backup: false

--- a/modules/datastore/postgres/aws-rds-blackbuck/1.0/main.tf
+++ b/modules/datastore/postgres/aws-rds-blackbuck/1.0/main.tf
@@ -1,0 +1,334 @@
+# PostgreSQL RDS Instance Implementation
+
+resource "random_password" "master_password" {
+  count   = var.instance.spec.restore_config.restore_from_backup ? 0 : 1
+  length  = 16
+  special = true
+  upper   = true
+  lower   = true
+  numeric = true
+  # Exclude RDS-forbidden characters: /, @, ", space
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+
+  lifecycle {
+    ignore_changes = [
+      length,
+      override_special,
+    ]
+  }
+}
+
+# Locals for computed values
+locals {
+  # Import flag
+  import_enabled = lookup(var.instance.spec, "imports", null) != null ? lookup(var.instance.spec.imports, "import_existing", false) : false
+
+  # Check if we're importing
+  is_importing = local.import_enabled ? lookup(var.instance.spec.imports, "db_instance_identifier", null) != null : false
+
+  # Resource naming with length constraints
+  db_instance_identifier = substr("${var.instance_name}-${var.environment.unique_name}", 0, 63)
+  subnet_group_name      = substr("${var.instance_name}-${var.environment.unique_name}-subnet-group", 0, 63)
+  security_group_name    = substr("${var.instance_name}-${var.environment.unique_name}-sg", 0, 63)
+
+  # Use imported or created subnet group
+  actual_subnet_group_name = local.import_enabled ? (lookup(var.instance.spec.imports, "subnet_group_name", null) != null ? var.instance.spec.imports.subnet_group_name : (length(aws_db_subnet_group.postgres) > 0 ? aws_db_subnet_group.postgres[0].name : null)) : (length(aws_db_subnet_group.postgres) > 0 ? aws_db_subnet_group.postgres[0].name : null)
+
+  # Use imported or created security group
+  actual_security_group_id = local.import_enabled ? (lookup(var.instance.spec.imports, "security_group_id", null) != null ? var.instance.spec.imports.security_group_id : (length(aws_security_group.postgres) > 0 ? aws_security_group.postgres[0].id : null)) : (length(aws_security_group.postgres) > 0 ? aws_security_group.postgres[0].id : null)
+
+  # Determine the correct source DB identifier for replicas
+  # Use imported identifier if importing, otherwise use the generated identifier
+  replica_source_identifier = local.is_importing ? lookup(var.instance.spec.imports, "db_instance_identifier", aws_db_instance.postgres.identifier) : aws_db_instance.postgres.identifier
+
+  # Parameter group name for consistency
+  parameter_group_for_replica = "default.postgres${split(".", var.instance.spec.version_config.engine_version)[0]}"
+
+  # Add suffix to replica names when importing to avoid conflicts with existing replicas
+  # This ensures new Terraform-managed replicas don't conflict with pre-existing unmanaged replicas
+  # Reserve 15 characters for suffix: "-imp-replica-5" (worst case scenario)
+  # This leaves 48 characters for the base identifier when importing, 52 when not importing
+
+  # Helper to truncate without ending on hyphen
+  base_for_import = substr(local.db_instance_identifier, 0, 44)
+  base_cleaned    = substr(local.base_for_import, -1, 1) == "-" ? substr(local.base_for_import, 0, 43) : local.base_for_import
+
+  replica_identifier_base = local.is_importing ? substr("${local.base_cleaned}imp", 0, 47) : substr(local.db_instance_identifier, 0, 52)
+
+  # Master credentials
+  master_username = var.instance.spec.restore_config.restore_from_backup ? var.instance.spec.restore_config.master_username : var.instance.spec.version_config.master_username
+  master_password = var.instance.spec.restore_config.restore_from_backup ? var.instance.spec.restore_config.master_password : random_password.master_password[0].result
+
+  # Database configuration
+  database_name = var.instance.spec.version_config.database_name
+
+  # Port configuration
+  db_port = 5432
+
+  # ---- migration-parity (aws-rds-blackbuck) ----
+  storage_type = lookup(var.instance.spec.sizing, "storage_type", "gp3")
+  max_allocated_storage = (lookup(var.instance.spec.sizing, "max_allocated_storage", 0) > 0
+  ? var.instance.spec.sizing.max_allocated_storage : null)
+
+  pgrp  = lookup(var.instance.spec, "parameter_group", {})
+  bkp   = lookup(var.instance.spec, "backup_config", {})
+  netcf = lookup(var.instance.spec, "network_config", {})
+
+  kms_key_arn_input = lookup(var.instance.spec.security_config, "kms_key_arn", null)
+  create_kms_key    = local.kms_key_arn_input == null || local.kms_key_arn_input == ""
+  kms_key_arn       = local.create_kms_key ? aws_kms_key.postgres[0].arn : local.kms_key_arn_input
+
+  pg_major               = split(".", var.instance.spec.version_config.engine_version)[0]
+  db_parameters          = lookup(local.pgrp, "parameters", {})
+  create_parameter_grp   = length(local.db_parameters) > 0
+  parameter_group_family = "postgres${local.pg_major}"
+  parameter_group_name = (local.create_parameter_grp
+    ? aws_db_parameter_group.postgres[0].name
+  : "default.postgres${local.pg_major}")
+
+  backup_retention_period = lookup(local.bkp, "retention_days", 7)
+  backup_window           = lookup(local.bkp, "backup_window", "03:00-04:00")
+  maintenance_window      = lookup(local.bkp, "maintenance_window", "sun:04:00-sun:05:00")
+
+  use_db_subnets       = lookup(local.netcf, "use_database_subnets", true)
+  published_db_subnets = try(var.inputs.vpc_details.attributes.database_subnet_ids, [])
+  db_subnet_ids = (local.use_db_subnets && length(local.published_db_subnets) > 0
+    ? local.published_db_subnets
+  : var.inputs.vpc_details.attributes.private_subnet_ids)
+
+  allowed_cidrs = distinct(concat(
+    [var.inputs.vpc_details.attributes.vpc_cidr_block],
+    lookup(var.instance.spec.security_config, "allowed_cidrs", [])
+  ))
+
+  # Common tags
+  common_tags = merge(var.environment.cloud_tags, {
+    Name            = local.db_instance_identifier
+    DatabaseEngine  = "postgres"
+    BackupRetention = tostring(local.backup_retention_period)
+  })
+}
+
+# ---- migration-parity resources (aws-rds-blackbuck) ----
+
+resource "aws_kms_key" "postgres" {
+  count = local.create_kms_key ? 1 : 0
+
+  description             = "CMK for RDS PostgreSQL ${local.db_instance_identifier}"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+
+  tags = merge(local.common_tags, {
+    Name   = "${local.db_instance_identifier}-kms"
+    Flavor = "aws-rds-blackbuck"
+  })
+}
+
+resource "aws_kms_alias" "postgres" {
+  count = local.create_kms_key ? 1 : 0
+
+  name          = "alias/${substr(local.db_instance_identifier, 0, 200)}-rds"
+  target_key_id = aws_kms_key.postgres[0].key_id
+}
+
+resource "aws_db_parameter_group" "postgres" {
+  count = local.create_parameter_grp ? 1 : 0
+
+  name   = substr("${local.db_instance_identifier}-pg", 0, 255)
+  family = local.parameter_group_family
+
+  dynamic "parameter" {
+    for_each = local.db_parameters
+    content {
+      name         = parameter.key
+      value        = parameter.value
+      apply_method = "pending-reboot"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(local.common_tags, {
+    Name   = "${local.db_instance_identifier}-pg"
+    Flavor = "aws-rds-blackbuck"
+  })
+}
+
+# DB Subnet Group - only create if not importing
+resource "aws_db_subnet_group" "postgres" {
+  count = local.import_enabled ? (lookup(var.instance.spec.imports, "subnet_group_name", null) != null ? 0 : 1) : 1
+
+  name       = local.subnet_group_name
+  subnet_ids = local.db_subnet_ids
+
+  tags = merge(local.common_tags, {
+    Name = "${local.db_instance_identifier}-subnet-group"
+  })
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+    ignore_changes = [
+      # Ignore tag changes that might occur outside Terraform
+      tags["LastModified"],
+    ]
+  }
+}
+
+# Security Group for RDS - only create if not importing
+resource "aws_security_group" "postgres" {
+  count = local.import_enabled ? (lookup(var.instance.spec.imports, "security_group_id", null) != null ? 0 : 1) : 1
+
+  name_prefix = "${local.security_group_name}-"
+  vpc_id      = var.inputs.vpc_details.attributes.vpc_id
+  description = "Security group for PostgreSQL RDS instance ${local.db_instance_identifier}"
+
+  # Ingress rule for PostgreSQL
+  ingress {
+    from_port   = local.db_port
+    to_port     = local.db_port
+    protocol    = "tcp"
+    cidr_blocks = local.allowed_cidrs
+    description = "PostgreSQL access from VPC and any explicitly allowed CIDRs"
+  }
+
+  # Egress rule (minimal required for RDS)
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound traffic"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.db_instance_identifier}-sg"
+  })
+
+  lifecycle {
+    prevent_destroy       = false
+    create_before_destroy = true
+  }
+}
+
+# RDS Instance
+resource "aws_db_instance" "postgres" {
+  # Basic configuration
+  identifier     = local.db_instance_identifier
+  engine         = "postgres"
+  engine_version = var.instance.spec.version_config.engine_version
+  instance_class = var.instance.spec.sizing.instance_class
+
+  # Database configuration
+  db_name = local.database_name
+  # Conditional credentials - only set when not restoring from snapshot or importing
+  username = local.master_username
+  password = local.master_password
+  port     = local.db_port
+
+  # Storage configuration
+  allocated_storage     = var.instance.spec.sizing.allocated_storage
+  max_allocated_storage = local.max_allocated_storage
+  storage_type          = local.storage_type
+  storage_encrypted     = true # Always encrypted
+  kms_key_id            = local.kms_key_arn
+
+  # Network configuration
+  db_subnet_group_name   = local.actual_subnet_group_name
+  vpc_security_group_ids = local.actual_security_group_id != null ? [local.actual_security_group_id] : []
+  publicly_accessible    = false # Always private
+
+  # Backup configuration (hardcoded for security)
+  backup_retention_period = local.backup_retention_period
+  backup_window           = local.backup_window
+  maintenance_window      = local.maintenance_window
+  copy_tags_to_snapshot   = true
+
+  # High availability
+  multi_az = var.instance.spec.sizing.multi_az
+
+  # Monitoring (disable enhanced monitoring to avoid IAM role requirement)
+  monitoring_interval          = 0
+  performance_insights_enabled = true
+
+  # Snapshot identifier for restore (conditional)
+  snapshot_identifier = var.instance.spec.restore_config.restore_from_backup ? var.instance.spec.restore_config.source_db_instance_identifier : null
+
+  # Parameter group (use default for now)
+  parameter_group_name = local.parameter_group_name
+
+  # Deletion protection (configurable for testing)
+  deletion_protection = var.instance.spec.security_config.deletion_protection
+
+  # Final snapshot configuration - skip snapshots for faster destroy
+  skip_final_snapshot = true
+  # Don't set final_snapshot_identifier when skipping to avoid validation errors
+
+  tags = local.common_tags
+
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes = [
+      # Ignore changes that would trigger recreation when importing
+      db_subnet_group_name,
+      vpc_security_group_ids,
+      # Ignore password and username when importing since we don't know them
+      username,
+      password,
+      # Ignore snapshot identifier after initial creation/import
+      snapshot_identifier
+    ]
+  }
+}
+
+# Read Replicas (always allow creation based on read_replica_count)
+resource "aws_db_instance" "read_replicas" {
+  count = var.instance.spec.sizing.read_replica_count
+
+  # Basic configuration
+  # Use replica_identifier_base which adds "-imported" suffix when importing to avoid conflicts
+  identifier          = "${local.replica_identifier_base}-replica-${count.index + 1}"
+  replicate_source_db = local.replica_source_identifier
+  instance_class      = var.instance.spec.sizing.instance_class
+
+  # Use same security group as primary
+  vpc_security_group_ids = local.actual_security_group_id != null ? [local.actual_security_group_id] : []
+  publicly_accessible    = false
+
+  # Storage configuration (inherited from source)
+  storage_encrypted = true
+
+  # High availability for replicas
+  multi_az = false # Read replicas don't need multi-AZ
+
+  skip_final_snapshot = true
+
+  # Monitoring (disable enhanced monitoring to avoid IAM role requirement)
+  monitoring_interval          = 0
+  performance_insights_enabled = true
+
+  # Parameter group (use consistent parameter group)
+  parameter_group_name = local.parameter_group_for_replica
+
+  tags = merge(local.common_tags, {
+    Name = "${local.replica_identifier_base}-replica-${count.index + 1}"
+    Role = "ReadReplica"
+  })
+
+  lifecycle {
+    prevent_destroy = false
+    ignore_changes = [
+      # Ignore changes to the source DB after creation
+      replicate_source_db,
+      # Ignore security group changes that might happen on the primary
+      vpc_security_group_ids,
+      # Ignore parameter group changes that might occur after primary instance changes
+      parameter_group_name
+    ]
+  }
+
+  # Ensure replicas are created after primary instance is fully created
+  depends_on = [aws_db_instance.postgres]
+}

--- a/modules/datastore/postgres/aws-rds-blackbuck/1.0/outputs.tf
+++ b/modules/datastore/postgres/aws-rds-blackbuck/1.0/outputs.tf
@@ -1,0 +1,35 @@
+locals {
+  output_attributes = {}
+  output_interfaces = {
+    reader = {
+      host     = length(aws_db_instance.read_replicas) > 0 ? aws_db_instance.read_replicas[0].address : aws_db_instance.postgres.address
+      port     = tostring(aws_db_instance.postgres.port)
+      username = aws_db_instance.postgres.username
+      password = local.is_importing ? var.instance.spec.imports.master_password : local.master_password
+      connection_string = format(
+        "postgres://%s:%s@%s:%d/%s",
+        aws_db_instance.postgres.username,
+        local.is_importing ? var.instance.spec.imports.master_password : local.master_password,
+        length(aws_db_instance.read_replicas) > 0 ? aws_db_instance.read_replicas[0].address : aws_db_instance.postgres.address,
+        aws_db_instance.postgres.port,
+        aws_db_instance.postgres.db_name
+      )
+      secrets = ["password", "connection_string"]
+    }
+    writer = {
+      host     = aws_db_instance.postgres.address
+      port     = tostring(aws_db_instance.postgres.port)
+      username = aws_db_instance.postgres.username
+      password = local.is_importing ? var.instance.spec.imports.master_password : local.master_password
+      connection_string = format(
+        "postgres://%s:%s@%s:%d/%s",
+        aws_db_instance.postgres.username,
+        local.is_importing ? var.instance.spec.imports.master_password : local.master_password,
+        aws_db_instance.postgres.address,
+        aws_db_instance.postgres.port,
+        aws_db_instance.postgres.db_name
+      )
+      secrets = ["password", "connection_string"]
+    }
+  }
+}

--- a/modules/datastore/postgres/aws-rds-blackbuck/1.0/variables.tf
+++ b/modules/datastore/postgres/aws-rds-blackbuck/1.0/variables.tf
@@ -1,0 +1,107 @@
+variable "instance" {
+  description = "Managed PostgreSQL database using Amazon RDS with secure defaults and backup support"
+  type = object({
+    kind    = string
+    flavor  = string
+    version = string
+    spec = object({
+      version_config = object({
+        engine_version = string
+        database_name  = string
+        # Optional: falls back to "pgadmin", which is what main.tf used unconditionally
+        # before this attribute was reachable from the spec.
+        master_username = optional(string, "pgadmin")
+      })
+      sizing = object({
+        instance_class        = string
+        allocated_storage     = number
+        storage_type          = optional(string, "gp3")
+        max_allocated_storage = optional(number, 0)
+        read_replica_count    = number
+        # Optional: defaults to true, which is what main.tf hardcoded before this
+        # attribute existed. Set false to match a single-AZ source instance.
+        multi_az = optional(bool, true)
+      })
+      security_config = object({
+        deletion_protection = bool
+        kms_key_arn         = optional(string)
+        allowed_cidrs       = optional(list(string), [])
+      })
+      parameter_group = optional(object({
+        parameters = optional(map(string), {})
+      }), {})
+      backup_config = optional(object({
+        retention_days     = optional(number, 7)
+        backup_window      = optional(string, "03:00-04:00")
+        maintenance_window = optional(string, "sun:04:00-sun:05:00")
+      }), {})
+      network_config = optional(object({
+        use_database_subnets = optional(bool, true)
+      }), {})
+      restore_config = optional(object({
+        restore_from_backup           = bool
+        source_db_instance_identifier = optional(string)
+        master_username               = optional(string)
+        master_password               = optional(string)
+      }), { restore_from_backup = false })
+      imports = optional(object({
+        import_existing        = optional(bool, false)
+        db_instance_identifier = optional(string)
+        subnet_group_name      = optional(string)
+        security_group_id      = optional(string)
+        master_password        = optional(string)
+      }))
+    })
+  })
+
+  validation {
+    condition = alltrue([
+      for c in lookup(var.instance.spec.security_config, "allowed_cidrs", []) :
+      !contains(["0.0.0.0/0", "::/0"], c)
+    ])
+    error_message = "allowed_cidrs must not contain an open CIDR (0.0.0.0/0 or ::/0). Grant the specific ranges that need access."
+  }
+
+  validation {
+    condition = alltrue([
+      for c in lookup(var.instance.spec.security_config, "allowed_cidrs", []) :
+      can(cidrnetmask(c))
+    ])
+    error_message = "Every entry in allowed_cidrs must be a valid IPv4 CIDR."
+  }
+}
+
+variable "instance_name" {
+  description = "The architectural name for the resource as added in the Facets blueprint designer."
+  type        = string
+}
+
+variable "environment" {
+  description = "An object containing details about the environment."
+  type = object({
+    name        = string
+    unique_name = string
+    cloud_tags  = map(string)
+  })
+}
+
+variable "inputs" {
+  description = "A map of inputs requested by the module developer."
+  type = object({
+    aws_provider = object({
+      attributes = object({
+        aws_iam_role = string
+        session_name = string
+        external_id  = string
+        aws_region   = string
+      })
+    })
+    vpc_details = object({
+      attributes = object({
+        vpc_id             = string
+        private_subnet_ids = list(string)
+        vpc_cidr_block     = string
+      })
+    })
+  })
+}

--- a/outputs/aws-vpc-details/outputs.yaml
+++ b/outputs/aws-vpc-details/outputs.yaml
@@ -10,6 +10,14 @@ properties:
           items:
             type: string
           type: array
+        database_subnet_group_name:
+          description: Name of the DB subnet group spanning the database subnets
+          type: string
+        database_subnet_ids:
+          description: List of IDs of the isolated database subnets (no default route)
+          items:
+            type: string
+          type: array
         internet_gateway_id:
           description: The ID of the Internet Gateway
           type: string


### PR DESCRIPTION
**Stacked on #389** — base branch is `fix/rds-modules-version-class-username`, so review that first. Retarget to `main` once #389 merges.

Adds `mysql/aws-rds-blackbuck/1.0` and `postgres/aws-rds-blackbuck/1.0`, plus the two output-type fields they need.

## Why a new flavor instead of extending `aws-rds`

`datastore_module_standards.md` targets developers who are not cloud experts and **forbids** ops-centric fields — *"Backup schedules or retention policies"*, *"Networking details (VPC, subnets, security groups)"*, maintenance windows — while mandating Multi-AZ, backups and encryption be hardcoded. That is the right design for greenfield databases.

It has no answer for onboarding an **existing** estate, where the settings the standard hides are exactly the ones that must be reproduced. Concretely, from a real 22-instance estate:

- Losing the custom parameter group drops `max_connections` **500 → ~85** on a `t4g.micro`, collapsing connection pools.
- PostgreSQL's default group sets `rds.force_ssl=1` against a source running `0`, which **refuses every non-TLS client** at cutover — and those connection strings are baked into container images.

So these flavors break the standard deliberately, and say so in their own `description`. `aws-rds` remains the standards-compliant choice for new databases.

## What they add

| Field | Behaviour |
|---|---|
| `security_config.kms_key_arn` | Supply a key, or leave blank and the module creates a dedicated CMK with rotation. Encryption always on either way. One shared ARN across all databases reproduces a single-key estate. |
| `parameter_group.parameters` | Supply any parameter → module creates a group. Leave empty → RDS engine default, i.e. exactly today's behaviour. |
| `backup_config.*` | Retention days, backup window, maintenance window. Previously hardcoded 7 days / fixed windows. |
| `security_config.allowed_cidrs` | Extra SG ingress on top of the VPC CIDR, **validated to reject `0.0.0.0/0` and `::/0`**. |
| `network_config.use_database_subnets` | Place databases in the network module's isolated database subnets (no default route). Falls back to private subnets when unavailable. |
| `security_config.deletion_protection` (mysql) | postgres already had it; mysql hardcoded `false` *alongside* `skip_final_snapshot = true`. |
| `sizing.storage_type` / `max_allocated_storage` (postgres) | Type was pinned to gp3; ceiling forced to `allocated * 2`. |

On `allowed_cidrs`: the source estate has an open `0.0.0.0/0` rule on 3306 for a payments-adjacent database. This flavor can restore the *legitimate* access — a peer account, Jenkins, a GCP range — while refusing to reproduce that.

## Fixes carried in

- **PostgreSQL DSN was malformed.** `.endpoint` already carries `:5432` and `.port` was appended again, producing `postgres://user:pass@host:5432:5432/db` on **both** reader and writer interfaces. Now uses `.address`, matching mysql.
- **`prevent_destroy` set to `false`.** Terraform requires a literal there so it cannot be made configurable; `true` is wrong for a migration that may need to re-run, and AWS-side `deletion_protection` now covers the real risk.
- **`kms_key_id` removed from `ignore_changes`.** The module manages the key now, and silently swallowing a changed ARN is the same defect class this work exists to fix.

## Output type change

`outputs/aws-vpc-details` gains `database_subnet_ids` and `database_subnet_group_name`.

The network module already **emits** both (`modules/network/aws_network/1.0/outputs.tf:6-10`) but the type never declared them — so the control plane offered no expression for either, and the database subnets it builds were unreachable. Verified with `raptor describe expressions`: neither appears. That is a **RULE-012 violation independent of this PR**; the change is purely additive.

## Validation

`terraform validate` passes on both. `raptor create iac-module --dry-run` passes every stage on both, including `var.instance.spec validated successfully`.

Trivy reports findings inherited from the base flavors, in blocks these modules do not change: mysql `AWS-0080` + `AWS-0104`, postgres `AWS-0104`. `AWS-0080` ("RDS encryption not enabled") is a false positive here — `storage_encrypted = true` is hardcoded and this flavor now also sets `kms_key_id`.

## Not addressed

`snapshot_identifier` on mysql (`M2`) — point-in-time restore is same-account-only, so for a cross-account migration the data path is DMS/CDC or dump-restore regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)