### PR TITLE
fix(service/aws): admit advertised spec fields, strip nulls before chart, fix nodepool input nesting

### DIFF
--- a/modules/service/aws/1.0/facets.yaml
+++ b/modules/service/aws/1.0/facets.yaml
@@ -501,6 +501,38 @@ spec:
                 - HttpCheck
                 - ExecCheck
               description: Repeated interval for health-check (in sec)
+            readiness_failure_threshold:
+              type: integer
+              title: Readiness Failure Threshold
+              minimum: 1
+              maximum: 10000
+              x-ui-placeholder: Enter readiness failure threshold for the Pod
+              x-ui-error-message: Value doesn't match pattern, accepted values are
+                from 1-10000
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.readiness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Consecutive probe failures before the check is considered
+                failed
+            readiness_success_threshold:
+              type: integer
+              title: Readiness Success Threshold
+              minimum: 1
+              maximum: 10000
+              x-ui-placeholder: Enter readiness success threshold for the Pod
+              x-ui-error-message: Value doesn't match pattern, accepted values are
+                from 1-10000
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.readiness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Consecutive probe successes before the check is considered
+                passing
             readiness_port:
               type: string
               title: Readiness Port
@@ -595,6 +627,38 @@ spec:
                 - HttpCheck
                 - ExecCheck
               description: Interval for Liveness (in sec)
+            liveness_failure_threshold:
+              type: integer
+              title: Liveness Failure Threshold
+              minimum: 1
+              maximum: 10000
+              x-ui-placeholder: Enter liveness failure threshold for the Pod
+              x-ui-error-message: Value doesn't match pattern, accepted values are
+                from 1-10000
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.liveness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Consecutive probe failures before the check is considered
+                failed
+            liveness_success_threshold:
+              type: integer
+              title: Liveness Success Threshold
+              minimum: 1
+              maximum: 10000
+              x-ui-placeholder: Enter liveness success threshold for the Pod
+              x-ui-error-message: Value doesn't match pattern, accepted values are
+                from 1-10000
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.liveness_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Consecutive probe successes before the check is considered
+                passing
             liveness_port:
               type: string
               title: Liveness Port
@@ -689,6 +753,38 @@ spec:
                 - HttpCheck
                 - ExecCheck
               description: Repeated interval for health-check (in sec)
+            startup_failure_threshold:
+              type: integer
+              title: Startup Failure Threshold
+              minimum: 1
+              maximum: 10000
+              x-ui-placeholder: Enter startup failure threshold for the Pod
+              x-ui-error-message: Value doesn't match pattern, accepted values are
+                from 1-10000
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.startup_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Consecutive probe failures before the check is considered
+                failed
+            startup_success_threshold:
+              type: integer
+              title: Startup Success Threshold
+              minimum: 1
+              maximum: 10000
+              x-ui-placeholder: Enter startup success threshold for the Pod
+              x-ui-error-message: Value doesn't match pattern, accepted values are
+                from 1-10000
+              x-ui-visible-if:
+                field: spec.runtime.health_checks.startup_check_type
+                values:
+                - PortCheck
+                - HttpCheck
+                - ExecCheck
+              description: Consecutive probe successes before the check is considered
+                passing
             startup_port:
               type: string
               title: Startup Port
@@ -785,6 +881,17 @@ spec:
                 field: spec.runtime.autoscaling.scaling_on
                 values:
                 - RAM
+        instance_count:
+          type: integer
+          title: Instance Count
+          description: Fixed number of replicas when autoscaling is not configured
+          minimum: 1
+          maximum: 200
+          x-ui-visible-if:
+            field: spec.type
+            values:
+            - application
+            - statefulset
         metrics:
           type: object
           title: Metrics
@@ -1926,11 +2033,7 @@ sample:
     runtime:
       args: []
       command: []
-      autoscaling:
-        scaling_on: CPU
-        min: 1
-        max: 1
-        cpu_threshold: '50'
+      instance_count: 1
       ports: {}
       size:
         cpu: 300m

--- a/modules/service/aws/1.0/main.tf
+++ b/modules/service/aws/1.0/main.tf
@@ -4,9 +4,83 @@ locals {
 
   aws_advanced_config   = lookup(lookup(var.instance, "advanced", {}), "aws", {})
   aws_cloud_permissions = lookup(lookup(local.spec, "cloud_permissions", {}), "aws", {})
-  enable_irsa           = lookup(local.aws_cloud_permissions, "enable_irsa", lookup(local.aws_advanced_config, "enable_irsa", false))
-  iam_arns              = lookup(local.aws_cloud_permissions, "iam_policies", lookup(local.aws_advanced_config, "iam", {}))
-  sa_name               = lower(var.instance_name)
+  # coalesce, not lookup fallbacks: lookup returns a present-but-null value
+  # (which optional(bool) produces) instead of the fallback, crashing every
+  # count/ternary downstream (S6)
+  enable_irsa = coalesce(
+    lookup(local.aws_cloud_permissions, "enable_irsa", null),
+    lookup(local.aws_advanced_config, "enable_irsa", null),
+    false
+  )
+  iam_arns = lookup(local.aws_cloud_permissions, "iam_policies", lookup(local.aws_advanced_config, "iam", {}))
+  sa_name  = lower(var.instance_name)
+
+  # ---- Null-stripping (S5) -------------------------------------------------
+  # optional() attributes with no default are emitted as null. yamlencode
+  # forwards them, helm's hasKey treats them as present, and the chart either
+  # crashes (autoscaling/health_checks: "wrong type for value ... got
+  # interface {}") or renders invalid manifests (cpu_limit/service_port).
+  # Strip nulls at every level before the spec reaches the chart.
+  runtime_raw = lookup(local.spec, "runtime", {})
+
+  size_clean = { for k, v in lookup(local.runtime_raw, "size", {}) : k => v if v != null }
+  ports_clean = { for pk, pv in lookup(local.runtime_raw, "ports", {}) :
+    pk => { for k, v in pv : k => v if v != null }
+  }
+  hc_raw   = lookup(local.runtime_raw, "health_checks", null)
+  hc_clean = local.hc_raw == null ? null : { for k, v in local.hc_raw : k => v if v != null }
+  as_raw   = lookup(local.runtime_raw, "autoscaling", null)
+  as_clean = local.as_raw == null ? null : { for k, v in local.as_raw : k => v if v != null }
+
+  release_raw    = lookup(local.spec, "release", {})
+  strategy_raw   = lookup(local.release_raw, "strategy", null)
+  disruption_raw = lookup(local.release_raw, "disruption_policy", null)
+  release_clean = merge(
+    { for k, v in local.release_raw : k => v if v != null && !contains(["strategy", "disruption_policy"], k) },
+    local.strategy_raw == null ? {} : { strategy = { for k, v in local.strategy_raw : k => v if v != null } },
+    local.disruption_raw == null ? {} : { disruption_policy = { for k, v in local.disruption_raw : k => v if v != null } },
+  )
+
+  sidecars_clean = {
+    for sc_name, sc in lookup(local.spec, "sidecars", {}) : sc_name => merge(
+      { for k, v in sc : k => v if v != null && k != "runtime" },
+      { runtime = merge(
+        { for k, v in lookup(sc, "runtime", {}) : k => v if v != null && k != "size" },
+        { size = { for k, v in lookup(lookup(sc, "runtime", {}), "size", {}) : k => v if v != null } },
+      ) },
+    )
+  }
+  init_containers_clean = {
+    for ic_name, ic in lookup(local.spec, "init_containers", {}) : ic_name => merge(
+      { for k, v in ic : k => v if v != null && k != "runtime" },
+      { runtime = merge(
+        { for k, v in lookup(ic, "runtime", {}) : k => v if v != null && k != "size" },
+        { size = { for k, v in lookup(lookup(ic, "runtime", {}), "size", {}) : k => v if v != null } },
+      ) },
+    )
+  }
+
+  runtime_clean = merge(
+    { for k, v in local.runtime_raw : k => v
+    if v != null && !contains(["size", "ports", "health_checks", "autoscaling"], k) },
+    { size = local.size_clean, ports = local.ports_clean },
+    local.hc_clean == null ? {} : { health_checks = local.hc_clean },
+    local.as_clean == null ? {} : { autoscaling = local.as_clean },
+  )
+
+  spec_clean = merge(
+    { for k, v in local.spec : k => v
+    if v != null && !contains(["runtime", "release", "sidecars", "init_containers"], k) },
+    {
+      runtime         = local.runtime_clean
+      release         = local.release_clean
+      sidecars        = local.sidecars_clean
+      init_containers = local.init_containers_clean
+    },
+  )
+
+  instance_clean = merge(var.instance, { spec = local.spec_clean })
+  # ---- end null-stripping --------------------------------------------------
 
   # Spec type for actions (application, cronjob, job, statefulset)
   spec_type                 = lookup(local.spec, "type", "application")
@@ -25,21 +99,18 @@ locals {
 
   image_pull_secrets = try(coalesce(var.inputs.artifactories.attributes.registry_secrets_list, []), [])
 
-  # Transform taints from object format to string format for utility module compatibility
+  # Node-pool taints/node_selector live under .attributes on the input wrapper,
+  # not at its top level (S8). The utility module's tolerations logic consumes
+  # taint OBJECTS ({key, value, effect}), so no string transformation is applied.
   kubernetes_node_pool_details = lookup(var.inputs, "kubernetes_node_pool_details", {})
-  node_pool_taints             = lookup(local.kubernetes_node_pool_details, "taints", [])
-  node_pool_labels             = lookup(local.kubernetes_node_pool_details, "node_selector", {})
+  node_pool_attributes         = try(var.inputs.kubernetes_node_pool_details.attributes, null)
+  node_pool_taints             = local.node_pool_attributes == null ? [] : local.node_pool_attributes.taints
+  node_pool_labels             = local.node_pool_attributes == null ? {} : local.node_pool_attributes.node_selector
 
-  # Convert taints from {key: "key", value: "value", effect: "effect"} to "key=value:effect" format
-  transformed_taints = [
-    for taint_name, taint_config in local.node_pool_taints :
-    "${taint_config.key}=${taint_config.value}:${taint_config.effect}"
-  ]
-
-  # Create modified inputs with transformed taints
+  # Surface taints/node_selector at the level the utility module reads them
   modified_inputs = merge(var.inputs, {
     kubernetes_node_pool_details = merge(local.kubernetes_node_pool_details, {
-      taints        = local.transformed_taints
+      taints        = local.node_pool_taints
       node_selector = local.node_pool_labels
     })
   })
@@ -75,7 +146,7 @@ locals {
   ) : []
 
   # Create instance configuration with VPA settings and topology spread constraints
-  instance_with_vpa_config = merge(var.instance, {
+  instance_with_vpa_config = merge(local.instance_clean, {
     advanced = merge(
       lookup(var.instance, "advanced", {}),
       {

--- a/modules/service/aws/1.0/variables.tf
+++ b/modules/service/aws/1.0/variables.tf
@@ -47,11 +47,41 @@ variable "instance" {
           protocol     = string
         })), {})
 
-        # Health checks (optional)
+        # Health checks (optional) - full shape mirroring facets.yaml so probe
+        # detail fields are not silently discarded by type conversion (S4/S7)
         health_checks = optional(object({
-          readiness_check_type = string
-          liveness_check_type  = string
+          readiness_check_type        = optional(string)
+          readiness_start_up_time     = optional(number)
+          readiness_timeout           = optional(number)
+          readiness_period            = optional(number)
+          readiness_port              = optional(string)
+          readiness_url               = optional(string)
+          readiness_exec_command      = optional(list(string))
+          readiness_failure_threshold = optional(number)
+          readiness_success_threshold = optional(number)
+          liveness_check_type         = optional(string)
+          liveness_start_up_time      = optional(number)
+          liveness_timeout            = optional(number)
+          liveness_period             = optional(number)
+          liveness_port               = optional(string)
+          liveness_url                = optional(string)
+          liveness_exec_command       = optional(list(string))
+          liveness_failure_threshold  = optional(number)
+          liveness_success_threshold  = optional(number)
+          startup_check_type          = optional(string)
+          startup_start_up_time       = optional(number)
+          startup_timeout             = optional(number)
+          startup_period              = optional(number)
+          startup_port                = optional(string)
+          startup_url                 = optional(string)
+          startup_headers             = optional(map(map(string)))
+          startup_exec_command        = optional(list(string))
+          startup_failure_threshold   = optional(number)
+          startup_success_threshold   = optional(number)
         }))
+
+        # Fixed replica count without an HPA (S11); ignored when autoscaling is set
+        instance_count = optional(number)
 
         # Autoscaling (optional)
         autoscaling = optional(object({
@@ -92,10 +122,20 @@ variable "instance" {
         }), {})
       })
 
-      # Release configuration
+      # Release configuration - strategy/disruption_policy mirrored from
+      # facets.yaml so they are not silently discarded (S9)
       release = optional(object({
         image             = optional(string)
         image_pull_policy = optional(string, "IfNotPresent")
+        strategy = optional(object({
+          type            = optional(string)
+          max_available   = optional(string)
+          max_unavailable = optional(string)
+        }))
+        disruption_policy = optional(object({
+          min_available   = optional(string)
+          max_unavailable = optional(string)
+        }))
       }), {})
 
       # Environment variables
@@ -201,12 +241,18 @@ variable "inputs" {
     })
 
     # Required: Kubernetes node pool details (Karpenter)
+    # taints/node_selector typed to match what kubernetes_node_pool/karpenter
+    # actually emits (list of objects / map), not strings (S8)
     kubernetes_node_pool_details = object({
       attributes = optional(object({
         node_class_name = optional(string)
         node_pool_name  = optional(string)
-        taints          = optional(string)
-        node_selector   = optional(string)
+        taints = optional(list(object({
+          key    = string
+          value  = string
+          effect = string
+        })), [])
+        node_selector = optional(map(string), {})
       }))
       interfaces = optional(object({}))
     })
@@ -249,10 +295,15 @@ variable "instance_name" {
 variable "environment" {
   description = "Environment configuration including namespace and other environment-specific settings"
   type = object({
-    name        = optional(string)
-    unique_name = string
-    namespace   = string
-    cloud_tags  = optional(map(string), {})
+    name                         = optional(string)
+    unique_name                  = string
+    namespace                    = string
+    cloud_tags                   = optional(map(string), {})
+    default_tolerations          = optional(list(any), [])
+    global_variables             = optional(map(string), {})
+    common_environment_variables = optional(map(string), {})
+    deployment_id                = optional(string, "")
+    secrets                      = optional(map(string), {})
   })
   default = {
     name        = "default"

--- a/outputs/aws_karpenter_nodepool/outputs.yaml
+++ b/outputs/aws_karpenter_nodepool/outputs.yaml
@@ -10,9 +10,20 @@ properties:
         node_pool_name:
           type: string
         taints:
-          type: string
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+              effect:
+                type: string
         node_selector:
-          type: string
+          type: object
+          additionalProperties:
+            type: string
     interfaces:
       type: object
       properties: {}


### PR DESCRIPTION
## What

Five verified defect classes in `service/aws/1.0`, all additive — no version bump per RULE-023:

| # | Defect | Fix |
|---|--------|-----|
| 1 | `variables.tf` types `health_checks` as only the two `check_type` strings → every probe detail field `facets.yaml` advertises is **silently discarded** (Terraform object-conversion drops undeclared attrs) → the chart renders **no probes at all** | Declared the full advertised shape + per-probe `*_failure_threshold` / `*_success_threshold` (chart already reads them; its default of 10 differs from the k8s-conventional 3) |
| 2 | `optional()` attrs with no default emit **null**; `yamlencode` forwards them and helm's `hasKey` treats them as present: `autoscaling: null` / `health_checks: null` are **fatal render errors**, null `cpu_limit`/`service_port` render invalid manifests | `main.tf` strips nulls at every level before values reach the chart. `autoscaling` must be *absent* (not `{}`) to not create an HPA — hence strip, not default |
| 3 | `enable_irsa = optional(bool)` yields null; `lookup()` returns present-but-null instead of its fallback → **plan crash** whenever `cloud_permissions` isn't authored | `coalesce()` chain |
| 4 | Node-pool `taints`/`node_selector` read at the input **wrapper** level (only keys: `attributes`/`interfaces`) → tolerations/nodeSelector **never applied**; the string transformation also fed strings to a utility module that consumes taint objects | Read from `.attributes`, pass objects. `outputs/aws_karpenter_nodepool` schema corrected to what the module actually emits (array of taint objects / map — was `string`) |
| 5 | `release.strategy`/`disruption_policy` advertised but undeclared; `runtime.instance_count` chart-read but unauthorable; `environment` type narrower than the k8s flavor | Declared; sample now uses `instance_count: 1` instead of an HPA-creating `autoscaling` block |

## Deliberate non-changes

- `advanced.common.app_chart.values` stays `optional(any)` — it's the working escape hatch (`additional_k8s_env_from`, `additional_k8s_objects`, `lifecycle`, `security_context`, …); tightening it under RULE-025 would break all of those.
- Utility-module source stays unpinned per repo convention (supply-chain pin tracked separately).
- Trivy: 8 pre-existing HIGH/CRITICAL findings on this module, identical before/after this change (same class as the eks_standard ones in `security-findings.md`).

## Verification

Terraform harness + `helm template` against the real `application/2.0` app-chart:
- probes render byte-identical to source k8s manifests (`failureThreshold: 3`, `successThreshold: 1`, `timeoutSeconds: 1`, `initialDelaySeconds: 50`, httpGet path/port)
- a minimal spec with **no** `health_checks`/`autoscaling`/limits renders cleanly (previously a fatal `wrong type for value` error) with **no HPA** and `replicas` via `instance_count`
- tolerations + nodeSelector render from a tainted Karpenter pool (previously always empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)